### PR TITLE
chore(codecov): make codecov configurable in repo

### DIFF
--- a/.codecov/codecov.yml
+++ b/.codecov/codecov.yml
@@ -1,0 +1,26 @@
+codecov:
+    notify:
+      require_ci_to_pass: yes
+  
+  coverage:
+    precision: 2
+    round: down
+    range: "70...100"
+  
+    status:
+      project: yes
+      patch: yes
+      changes: no
+  
+  parsers:
+    gcov:
+      branch_detection:
+        conditional: yes
+        loop: yes
+        method: no
+        macro: no
+  
+  comment:
+    layout: "header, diff"
+    behavior: default
+    require_changes: no

--- a/.codecov/codecov.yml
+++ b/.codecov/codecov.yml
@@ -1,26 +1,22 @@
 codecov:
     notify:
-      require_ci_to_pass: yes
-  
-  coverage:
+      require_ci_to_pass: yes  
+coverage:
     precision: 2
     round: down
     range: "70...100"
-  
     status:
-      project: yes
-      patch: yes
-      changes: no
-  
-  parsers:
+        project: yes
+        patch: yes
+        changes: no  
+parsers:
     gcov:
-      branch_detection:
-        conditional: yes
-        loop: yes
-        method: no
-        macro: no
-  
-  comment:
+        branch_detection:
+            conditional: yes
+            loop: yes
+            method: no
+            macro: no  
+comment:
     layout: "header, diff"
     behavior: default
     require_changes: no


### PR DESCRIPTION
This makes all `codecov` features configurable within the repo. Right now we use the default settings.

See [here](https://docs.codecov.io/v4.3.0/docs/codecov-yaml) for the options