### PR TITLE
chore: remove not existing upstream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/aws/aws-sdk-go v1.30.16 // indirect
 	github.com/caos/logging v0.0.1
 	github.com/cockroachdb/cockroach-go v0.0.0-20200411195601-6f5842749cfc
-	github.com/envoyproxy/protoc-gen-validate v0.3.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/mock v1.4.3


### PR DESCRIPTION
This not existing packet version does block dependabot.
I therefore removed it. As the build still passes i think everything is great.

![image](https://user-images.githubusercontent.com/9879976/80893964-149e5700-8cd7-11ea-8448-4d2bd6727d35.png)
