### PR TITLE
fix: missing password config

### DIFF
--- a/cmd/zitadel/startup.yaml
+++ b/cmd/zitadel/startup.yaml
@@ -35,6 +35,7 @@ AuthZ:
       Port: $ZITADEL_EVENTSTORE_PORT
       User: 'authz'
       Database: 'authz'
+      Password: $CR_AUTHZ_PASSWORD
       SSL:
         Mode: $CR_SSL_MODE
         RootCert: $CR_ROOT_CERT


### PR DESCRIPTION
not sure if `ssl=true` should be removed as well