### PR TITLE
fix(container): stop copying / and instead only copy zitadel

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,8 @@
 name: Docs
-on: push
-  # push:
-    # paths:
-    # - 'site/**'
+on:
+  push:
+    paths:
+      - 'site/**'
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -30,10 +30,7 @@ jobs:
     name: Deploy
     needs: builddocs
     runs-on: ubuntu-latest
-    # defaults:
-    #   run:
-    #     working-directory: ./site
-    # if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Checkout Repo
         uses: actions/checkout@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
       run: echo ${{ steps.vars.outputs.sha_short }}
     - name: Docker Login
       run: docker login $REGISTRY -u $GITHUB_ACTOR -p $GITHUB_TOKEN
-    - uses: anchore/scan-action@master
+    - uses: anchore/scan-action@v1
       with:
         image-reference: "${{ env.REGISTRY }}/${{ github.repository }}:${{ steps.vars.outputs.sha_short }}"
         dockerfile-path: "./build/docker/Dockerfile"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,35 +126,10 @@ jobs:
         repository: ${{ github.repository }}
         tag_with_ref: true
         tag_with_sha: true
-  
-  container-vulnerability-scan:
-    runs-on: ubuntu-18.04
-    needs: container-prod
-    steps:
-    - name: Source checkout
-      uses: actions/checkout@v2
-    - name: Generate Short SHA Container Tag
-      id: vars
-      run: echo "::set-output name=sha_short::SHA-$(git rev-parse --short HEAD)"
-    - name: Check outputs
-      run: echo ${{ steps.vars.outputs.sha_short }}
-    - name: Docker Login
-      run: docker login $REGISTRY -u $GITHUB_ACTOR -p $GITHUB_TOKEN
-    - uses: anchore/scan-action@v1
-      with:
-        image-reference: "${{ env.REGISTRY }}/${{ github.repository }}:${{ steps.vars.outputs.sha_short }}"
-        dockerfile-path: "./build/docker/Dockerfile"
-        fail-build: false
-        acs-report-enable: true
-        debug: true
-    - name: Upload Anchore Scan Report
-      uses: github/codeql-action/upload-sarif@v1
-      with:
-        sarif_file: results.sarif
 
   release:
     runs-on: ubuntu-18.04
-    needs: [container-prod]
+    needs: [container-prod, container-debug]
     env:
       DOCKER_USERNAME: ${{ github.actor }}
       DOCKER_PASSWORD: ${{ secrets.CR_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
 
   release:
     runs-on: ubuntu-18.04
-    needs: [container-prod, container-debug]
+    needs: [container-prod]
     env:
       DOCKER_USERNAME: ${{ github.actor }}
       DOCKER_PASSWORD: ${{ secrets.CR_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,7 @@ jobs:
         dockerfile-path: "./build/docker/Dockerfile"
         fail-build: false
         acs-report-enable: true
+        debug: true
     - name: Upload Anchore Scan Report
       uses: github/codeql-action/upload-sarif@v1
       with:

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -1,14 +1,14 @@
 # This Stage prepares the user in the container and copies the files
 FROM alpine:latest as prepare
 RUN adduser -D zitadel
-COPY .artifacts/zitadel-linux-amd64 /zitadel
-COPY cmd/zitadel/*.yaml /
-RUN chmod a+x /zitadel
+COPY .artifacts/zitadel-linux-amd64 /app/zitadel
+COPY cmd/zitadel/*.yaml /app
+RUN chmod a+x /app/zitadel
 
 # This Stage is intended as production image
 FROM scratch as final
 COPY --from=prepare /etc/passwd /etc/passwd
-COPY --from=prepare / /
+COPY --from=prepare /app /
 USER zitadel
 HEALTHCHECK NONE
 ENTRYPOINT ["/zitadel"]

--- a/build/docker/Dockerfile
+++ b/build/docker/Dockerfile
@@ -2,7 +2,7 @@
 FROM alpine:latest as prepare
 RUN adduser -D zitadel
 COPY .artifacts/zitadel-linux-amd64 /app/zitadel
-COPY cmd/zitadel/*.yaml /app
+COPY cmd/zitadel/*.yaml /app/
 RUN chmod a+x /app/zitadel
 
 # This Stage is intended as production image


### PR DESCRIPTION
This PR will:

- Remove **anchore** as we rely on scratch
- Update the docker file so that only **ZITADEL** files are copied into scratch