### PR TITLE
fix(zitadel): Remove unused Proto Import

### DIFF
--- a/proto/zitadel/features.proto
+++ b/proto/zitadel/features.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 
 import "zitadel/object.proto";
-import "google/protobuf/timestamp.proto";
 import "google/protobuf/duration.proto";
 
 package zitadel.features.v1;


### PR DESCRIPTION
Fix Warning `zitadel/features.proto: warning: Import google/protobuf/timestamp.proto but not used.`