### PR TITLE
chore(workflow): run docs on any branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,12 @@
 name: Docs
 on:
   push:
-    paths:
-      - 'site/**'
+    branches:
+     - '**'
     tags-ignore:
       - '**'
+    paths:
+      - 'site/**'
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/site/README.md
+++ b/site/README.md
@@ -22,3 +22,4 @@ DOCKER_BUILDKIT=1 docker build -f site/dockerfile . -t zitadel:docs -o docs
 ## Honorable Mentions
 
 This project was created with the help of some components from [svelte](https://github.com/sveltejs/svelte)([MIT](https://github.com/sveltejs/svelte/blob/master/LICENSE)) as well as [site-kit](https://github.com/sveltejs/site-kit)([MIT](https://github.com/sveltejs/site-kit/blob/master/LICENSE)).
+


### PR DESCRIPTION
tags-ignore does only work with branches defined as well: https://github.community/t/using-on-push-tags-ignore-and-paths-ignore-together/16931/2