### PR TITLE
feat: make x-zitadel-orgid optional (resource owner by default)

### DIFF
--- a/internal/api/authz/context.go
+++ b/internal/api/authz/context.go
@@ -80,6 +80,9 @@ func VerifyTokenAndCreateCtxData(ctx context.Context, token, orgID string, t *To
 	if err := checkOrigin(ctx, origins); err != nil {
 		return CtxData{}, err
 	}
+	if orgID == "" {
+		orgID = resourceOwner
+	}
 	return CtxData{
 		UserID:            userID,
 		OrgID:             orgID,


### PR DESCRIPTION
header will only be needed if an other org / multiple orgs a necessary