### PR TITLE
docs: fix CAP theorem acronym resolution

### DIFF
--- a/docs/docs/concepts/architecture.md
+++ b/docs/docs/concepts/architecture.md
@@ -20,7 +20,7 @@ This information is then passed to **command validation** for processing of the 
 - Transaction safety is a MUST
 - Availability MUST be high
 
-> When we classify this with the CAP theorem we would choose **Consistent** and **Available** but leave **Performance** aside.
+> When we classify this with the CAP theorem we would choose **Consistent** and **Available** but leave **Partition Tolerance** aside.
 
 ### Component Spooler
 


### PR DESCRIPTION
The `P` in `CAP` stands for network partition tolerance (see https://en.wikipedia.org/wiki/CAP_theorem).

Instead of CAP, you might want to refer to [PACELC](https://en.wikipedia.org/wiki/PACELC_theorem) instead, which is more applicable IMO.