### PR TITLE
chore: remove PAT and use GH Token

### DIFF
--- a/.github/workflows/zitadel.yml
+++ b/.github/workflows/zitadel.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
       - run: ls -la
@@ -136,7 +136,7 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
       - uses: docker/build-push-action@v2
@@ -221,7 +221,7 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
       - uses: docker/build-push-action@v2
@@ -240,7 +240,7 @@ jobs:
     runs-on: ubuntu-18.04
     needs: [ refs, zitadel-image, operator-image, crdb-image ]
     env:
-      DOCKER_USERNAME: ${{ github.actor }}
+      DOCKER_USERNAME: ${{ github.repository_owner }}
       DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Source checkout

--- a/.github/workflows/zitadel.yml
+++ b/.github/workflows/zitadel.yml
@@ -2,12 +2,14 @@ name: ZITADEL Release
 on:
   push:
     branches:
-      - '**'
+      - main
     tags-ignore:
+      - '**'
+  pull_request:
+    branches:
       - '**'
 
 env:
-  GITHUB_TOKEN: ${{ secrets.CR_PAT }}
   REGISTRY: ghcr.io
   NODE_VERSION: '12'
   GO_VERSION: '1.15'
@@ -74,7 +76,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: ${{ github.actor }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ env.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
       - run: ls -la
       - uses: docker/build-push-action@v2
@@ -135,7 +137,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: ${{ github.actor }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ env.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
       - uses: docker/build-push-action@v2
         name: onlybuild
@@ -220,7 +222,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: ${{ github.actor }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ env.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
       - uses: docker/build-push-action@v2
         name: buildandpush
@@ -239,7 +241,7 @@ jobs:
     needs: [ refs, zitadel-image, operator-image, crdb-image ]
     env:
       DOCKER_USERNAME: ${{ github.actor }}
-      DOCKER_PASSWORD: ${{ secrets.CR_PAT }}
+      DOCKER_PASSWORD: ${{ env.GITHUB_TOKEN }}
     steps:
       - name: Source checkout
         uses: actions/checkout@v2

--- a/.github/workflows/zitadel.yml
+++ b/.github/workflows/zitadel.yml
@@ -10,6 +10,7 @@ on:
       - '**'
 
 env:
+  GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
   REGISTRY: ghcr.io
   NODE_VERSION: '12'
   GO_VERSION: '1.15'

--- a/.github/workflows/zitadel.yml
+++ b/.github/workflows/zitadel.yml
@@ -2,12 +2,13 @@ name: ZITADEL Release
 on:
   push:
     branches:
-      - main
+      - '**'
     tags-ignore:
       - '**'
-  pull_request:
-    branches:
-      - '**'
+  # disabled due to a bug -> https://github.community/t/403-error-on-container-registry-push-from-github-action/173071/2
+  # pull_request:
+  #   branches:
+  #     - '**'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/zitadel.yml
+++ b/.github/workflows/zitadel.yml
@@ -10,7 +10,6 @@ on:
       - '**'
 
 env:
-  GITHUB_TOKEN: ${{ GITHUB_TOKEN }}
   REGISTRY: ghcr.io
   NODE_VERSION: '12'
   GO_VERSION: '1.15'
@@ -77,7 +76,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: ${{ github.actor }}
-          password: ${{ env.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
       - run: ls -la
       - uses: docker/build-push-action@v2
@@ -138,7 +137,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: ${{ github.actor }}
-          password: ${{ env.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
       - uses: docker/build-push-action@v2
         name: onlybuild
@@ -223,7 +222,7 @@ jobs:
         uses: docker/login-action@v1
         with:
           username: ${{ github.actor }}
-          password: ${{ env.GITHUB_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
           registry: ${{ env.REGISTRY }}
       - uses: docker/build-push-action@v2
         name: buildandpush
@@ -242,7 +241,7 @@ jobs:
     needs: [ refs, zitadel-image, operator-image, crdb-image ]
     env:
       DOCKER_USERNAME: ${{ github.actor }}
-      DOCKER_PASSWORD: ${{ env.GITHUB_TOKEN }}
+      DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Source checkout
         uses: actions/checkout@v2
@@ -325,7 +324,7 @@ jobs:
           tag: ${{ needs.refs.outputs.short_ref }}-dev
           commit: ${{ needs.refs.outputs.short_ref }}
           name: Branch ${{ needs.refs.outputs.short_ref }}
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           replacesArtifacts: true
           prerelease: true
           draft: false

--- a/.github/workflows/zitadel.yml
+++ b/.github/workflows/zitadel.yml
@@ -10,7 +10,7 @@ on:
       - '**'
 
 env:
-  GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ GITHUB_TOKEN }}
   REGISTRY: ghcr.io
   NODE_VERSION: '12'
   GO_VERSION: '1.15'

--- a/.github/workflows/zitadel.yml
+++ b/.github/workflows/zitadel.yml
@@ -246,8 +246,12 @@ jobs:
     steps:
       - name: Source checkout
         uses: actions/checkout@v2
-      - name: Docker Login
-        run: docker login $REGISTRY -u $GITHUB_ACTOR -p $GITHUB_TOKEN
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ${{ env.REGISTRY }}
       - name: Docker Pull ZITADEL Image
         run: docker pull $REGISTRY/$GITHUB_REPOSITORY:${{ needs.refs.outputs.sha_short }}
       - name: Docker Pull ZITADEL Operator Image

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ For example, **ZITADEL** is event sourced but it does not rely on a pub/sub syst
 ## Features of ZITADEL platform
 
 * Authentication
-    * OpenID Connect 1.0 Protocol (OP)
-    * Username / Password
-    * Machine-to-machine (JWT profile)
-    * Passwordless with FIDO2
+  * OpenID Connect 1.0 Protocol (OP)
+  * Username / Password
+  * Machine-to-machine (JWT profile)
+  * Passwordless with FIDO2
 * Multifactor authentication with OTP, U2F
 * Federation with OpenID Connect 1.0 Protocol (RP), OAuth 2.0 Protocol (RP)
 * Authorization via Role Based Access Control (RBAC)
@@ -66,11 +66,11 @@ Details need to be announced, but feel free to contribute already. As long as yo
 
 See the policy [here](./SECURITY.md)
 
-
 ## Other CAOS Projects
+
 * [**ORBOS**](https://github.com/caos/orbos/) - GitOps everything
 * [**OIDC for GO**](https://github.com/caos/oidc) - OpenID Connect SDK (client and server) for Go
-* [**ZITADEL Tools**](https://github.com/caos/zitadel-tools) - Go tool to convert  key file to privately signed JWT 
+* [**ZITADEL Tools**](https://github.com/caos/zitadel-tools) - Go tool to convert  key file to privately signed JWT
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For example, **ZITADEL** is event sourced but it does not rely on a pub/sub syst
 * APIs for Management, Administration, and Authentication
 * Policy configuration and enforcement
 
-## How To Use It
+## How To Use It 
 
 ### ZITADEL Cloud
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For example, **ZITADEL** is event sourced but it does not rely on a pub/sub syst
 * APIs for Management, Administration, and Authentication
 * Policy configuration and enforcement
 
-## How To Use It 
+## How To Use It
 
 ### ZITADEL Cloud
 


### PR DESCRIPTION
This PR prepares our pipeline so that we can accept external pull request (e.g. forked ones).
And also it removes my `PAT` and uses the `GH_TOKEN`

There is a bug with GH Actions so that the `on: pull_request` does terminate with a 403 [GH Bug](https://github.community/t/403-error-on-container-registry-push-from-github-action/173071/20?u=fforootd)