### PR TITLE
fix: tos and privacy links

### DIFF
--- a/console/src/app/app.component.html
+++ b/console/src/app/app.component.html
@@ -179,11 +179,11 @@
                         <span class="fill-space"></span>
 
                         <div class="toc-line">
-                            <a class="toc" [href]="https://docs.zitadel.ch/docs/legal/terms-of-service" alt="Terms and Conditions"
+                            <a class="toc" [href]="'https://docs.zitadel.ch/docs/legal/terms-of-service'" alt="Terms and Conditions"
                                 target="_blank">{{'MENU.TOS'
                                 | translate}}</a>
                                 <span class="slash">|</span>
-                            <a class="toc" [href]="https://docs.zitadel.ch/docs/legal/privacy-policy" alt="Privacy Policy "
+                            <a class="toc" [href]="'https://docs.zitadel.ch/docs/legal/privacy-policy'" alt="Privacy Policy "
                                 target="_blank">{{'MENU.PRIVACY'
                                 | translate}}</a>
                             <span>&nbsp;&nbsp;&nbsp;</span>

--- a/console/src/app/app.component.html
+++ b/console/src/app/app.component.html
@@ -179,11 +179,11 @@
                         <span class="fill-space"></span>
 
                         <div class="toc-line">
-                            <a class="toc" [href]="language == 'de' ? 'https://zitadel.ch/pdf/agb.pdf' : 'https://zitadel.ch/pdf/tos.pdf'" alt="Terms and Conditions"
+                            <a class="toc" [href]="https://docs.zitadel.ch/docs/legal/terms-of-service" alt="Terms and Conditions"
                                 target="_blank">{{'MENU.TOS'
                                 | translate}}</a>
                                 <span class="slash">|</span>
-                            <a class="toc" [href]="language == 'de' ? 'https://zitadel.ch/pdf/datenschutz.pdf' : 'https://zitadel.ch/pdf/privacy.pdf'" alt="Terms and Conditions"
+                            <a class="toc" [href]="https://docs.zitadel.ch/docs/legal/privacy-policy" alt="Privacy Policy "
                                 target="_blank">{{'MENU.PRIVACY'
                                 | translate}}</a>
                             <span>&nbsp;&nbsp;&nbsp;</span>

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -105,11 +105,11 @@ module.exports = {
             },
             {
               label: 'Terms and Conditions',
-              href: 'https://zitadel.ch/pdf/tos.pdf',
+              href: 'https://docs.zitadel.ch/docs/legal/terms-of-service',
             },
             {
               label: 'Privacy Policy',
-              href: 'https://zitadel.ch/pdf/privacy.pdf',
+              href: 'https://docs.zitadel.ch/docs/legal/privacy-policy',
             },
           ],
         },

--- a/internal/ui/login/static/i18n/de.yaml
+++ b/internal/ui/login/static/i18n/de.yaml
@@ -159,9 +159,9 @@ Registration:
   TosConfirm: Ich akzeptiere die
   TosLinkText: AGBs
   TosConfirmAnd: und die
-  TosLink: https://zitadel.ch/pdf/agb.pdf
+  TosLink: https://docs.zitadel.ch/docs/legal/terms-of-service
   PrivacyLinkText: Datenschutzerklärung
-  PrivacyLink: https://zitadel.ch/pdf/datenschutz.pdf
+  PrivacyLink: https://docs.zitadel.ch/docs/legal/privacy-policy
   ExternalLogin: oder registriere dich mit einem externen Benutzer
 
 RegistrationOrg:
@@ -186,9 +186,9 @@ RegistrationOrg:
   TosConfirm: Ich akzeptiere die
   TosLinkText: AGBs
   TosConfirmAnd: und die
-  TosLink: https://zitadel.ch/pdf/agb.pdf
+  TosLink: https://docs.zitadel.ch/docs/legal/terms-of-service
   PrivacyLinkText: Datenschutzerklärung
-  PrivacyLink: https://zitadel.ch/pdf/datenschutz.pdf
+  PrivacyLink: https://docs.zitadel.ch/docs/legal/privacy-policy
 
 LinkingUsersDone:
   Title: Benutzerlinking
@@ -227,9 +227,9 @@ Actions:
 Footer:
   PoweredBy: Powered By
   Tos: AGB
-  TosLink: https://zitadel.ch/pdf/agb.pdf
+  TosLink: https://docs.zitadel.ch/docs/legal/terms-of-service
   Privacy: Datenschutzerklärung
-  PrivacyLink: https://zitadel.ch/pdf/datenschutz.pdf
+  PrivacyLink: https://docs.zitadel.ch/docs/legal/privacy-policy
   Help: Hilfe
 
 Errors:

--- a/internal/ui/login/static/i18n/en.yaml
+++ b/internal/ui/login/static/i18n/en.yaml
@@ -159,9 +159,9 @@ Registration:
   TosConfirm: I accept the
   TosLinkText: TOS
   TosConfirmAnd: and the
-  TosLink: https://zitadel.ch/pdf/tos.pdf
+  TosLink: https://docs.zitadel.ch/docs/legal/terms-of-service
   PrivacyLinkText: privacy policy
-  PrivacyLink: https://zitadel.ch/pdf/privacy.pdf
+  PrivacyLink: https://docs.zitadel.ch/docs/legal/privacy-policy
   ExternalLogin: or register with an external user
 
 RegistrationOrg:
@@ -186,9 +186,9 @@ RegistrationOrg:
   TosConfirm: I accept the
   TosLinkText: TOS
   TosConfirmAnd: and the
-  TosLink: https://zitadel.ch/pdf/tos.pdf
+  TosLink: https://docs.zitadel.ch/docs/legal/terms-of-service
   PrivacyLinkText: privacy policy
-  PrivacyLink: https://zitadel.ch/pdf/privacy.pdf
+  PrivacyLink: https://docs.zitadel.ch/docs/legal/privacy-policy
 
 LoginSuccess:
   Title: Login successful
@@ -227,9 +227,9 @@ Actions:
 Footer:
   PoweredBy: Powered By
   Tos: TOS
-  TosLink: https://zitadel.ch/pdf/tos.pdf
+  TosLink: https://docs.zitadel.ch/docs/legal/terms-of-service
   Privacy: Privacy policy
-  PrivacyLink: https://zitadel.ch/pdf/privacy.pdf
+  PrivacyLink: https://docs.zitadel.ch/docs/legal/privacy-policy
   Help: Help
 
 Errors:


### PR DESCRIPTION
Should update the links to Terms of Service and the Privacy Policy throughout ZITADEL (footers, logins, ...)