### PR TITLE
fix: eventListener in input_suffix_offset.js

### DIFF
--- a/internal/ui/login/static/resources/scripts/input_suffix_offset.js
+++ b/internal/ui/login/static/resources/scripts/input_suffix_offset.js
@@ -1,8 +1,10 @@
 const suffix = document.getElementById('default-login-suffix');
 const suffixInput = document.getElementsByClassName('lgn-suffix-input')[0];
 
-calculateOffset();
-suffix.addEventListener("DOMCharacterDataModified", calculateOffset);
+if (suffix && suffixInput) {
+    calculateOffset();
+    suffix.addEventListener("DOMCharacterDataModified", calculateOffset);
+}
 
 function calculateOffset() {
     // add suffix width to inner right padding of the input field


### PR DESCRIPTION
fixes js error when no domain suffix is displayed:

![image](https://user-images.githubusercontent.com/9405495/126461313-f0747792-d195-4a52-96c9-cd55ce9622a5.png)
