### PR TITLE
docs: improve "Authenticate" how to guide

### DIFF
--- a/docs/docs/guides/authentication/authmethods/basic.mdx
+++ b/docs/docs/guides/authentication/authmethods/basic.mdx
@@ -1,25 +1,29 @@
 #### redirect_uri
 
-After selecting the authentication method, you can register a redirect_uri and post_logout_redirect_uri.
-The redirect_uri will be called after user authentication for code exchange.
+After selecting the authentication method, you can register a `redirect_uri` and `post_logout_redirect_uri`.
+After the user authenticates, the `redirect_uri` is called for code exchange.
 
-You can even register multiple, but typically one will be enough. If you need to distinguish between different scenarios
-or environments we recommend using the `state` parameter for the former and multiple projects for the latter.
+Typically one `redirect_uri` is enough, but you can have multiple.
+If you need to distinguish between different scenarios,
+we recommend using the `state` parameter.
+If you need to distinguish different environments, we recommend using multiple projects.
 
 ## Auth Request
 
-To initialize the user authentication, you will have to create an authorization request using HTTP GET in the user agent (browser)
-on /authorize with at least the following parameters:
+To initialize the user authentication, create an authorization request using HTTP GET in the user agent (browser) to `/authorize`.
+The request needs at least the following parameters:
 
-- `client_id`: this tells the authorization server which application it is, copy from Console
-- `redirect_uri`: where the authorization code is sent to after the user authentication, must be one of the registered in the previous step
-- `response_type`: if you want to have a code (authorization code flow) or directly a token (implicit flow), so when ever possible use `code`
-- `scope`: what scope you want to grant to the access_token / id_token, minimum is `openid`, if you're unsure what you need you might start with `openid profile email`
+- `client_id`: how the authorization server knows which application it is. Copy from Console.
+- `redirect_uri`: where the authorization code is sent to after the user authentication. Must be one of the registered URIs in the previous step.
+- `response_type`: whether you want to have a code (authorization code flow) or a token (implicit flow). Whenever possible, use `code`
+- `scope`: what scope you want to grant to the access_token / id_token, minimum is `openid`. If you're unsure what you need, you might start with `openid profile email`
 
-We recommend always using two additional parameters `state` and `nonce`. The former enables you to transfer a state through
-the authentication process. The latter is used to bind the client session with the id_token and to mitigate replay attacks.
+We recommend always using two additional parameters: `state` and `nonce`.
+`State` lets you to transfer a state through the authentication process.
+`Nonce` is used to bind the client session with the `id_token`, and to mitigate replay attacks.
 
-You don't need any additional parameter for this request. We're identifying the app by the `client_id` parameter.
+You don't need any additional parameters for this request.
+We identify the app by the `client_id` parameter.
 
 So your request might look like this (linebreaks and whitespace for display reasons):
 
@@ -34,38 +38,38 @@ curl --request GET \
 
 ### Additional parameters and customization
 
-There are additional parameters and values you can provide to satisfy your use case and to customize the user's authentication flow.
+To customize the user's authentication flow, there are additional parameters and values you can provide to satisfy your use case.
 Please check the [authorization_endpoint reference](/docs/apis/openidoauth/endpoints#authorization_endpoint) in the OAuth / OIDC documentation.
 
 ## Callback
 
-Regardless of a successful or error response from the authorization_endpoint, the authorization server will call your
-callback endpoint you provided by the `redirect_uri`.
+No matter whether the `authorization_endpoint` response returns a success message or an error,
+the authorization server will call the callback endpoint that you provided in the `redirect_uri`.
 
 :::note
-If the redirect_uri is not provided, was not registered or anything other prevents the auth server form returning the response to the client,
-the error will be display directly to the user on the auth server.
+If no `redirect_uri` is registered, or if anything else prevents the auth server from returning the response to the client,
+the error is displayed directly on the auth server.
 :::
 
-Upon successful authentication you'll be given a `code` and if provided the unmodified `state` parameter.
+Upon successful authentication, you'll be given a `code` and, if provided, the unmodified `state` parameter.
 You will need this `code` in the token request.
 
-If a parameter was missing, malformed or any other error occurred, your answer will contain an `error` stating the error type,
-possibly an `error_description` providing some information about the error and its reason and the `state` parameter.
+If a parameter is missing, malformed, or any other error occurred, your answer will contain an `error`.
+This error states the error type, and possibly gives an `error_description`, which provides some information about the error, its reason, and the `state` parameter.
 Check the [error response section](/docs/apis/openidoauth/endpoints#error-response) in the authorization_endpoint reference.
 
 ## Token request
 
-Next you will have to exchange the given `code` for the tokens. For this HTTP POST request (form-urlencoded) you will need to provide the following:
+Next you need to exchange the given `code` for the tokens. For this HTTP POST request (form-urlencoded), you need to provide the following:
 
-- code: the code that was issued from the authorization request
-- grant_type: must be `authorization_code`
-- redirect_uri: callback uri where the code was sent to. Must match exactly the redirect_uri of the authorization request
+- `code`: the code that was issued from the authorization request
+- `grant_type`: must be `authorization_code`
+- `redirect_uri`: callback URI where the code was sent to. Must match exactly the `redirect_uri` of the authorization request
 
-Depending on your authentication method you'll need additional headers and parameters:
+Depending on your authentication method, you'll need additional headers and parameters:
 
 Send your `client_id` and `client_secret` as Basic Auth Header. Note that OAuth2 requires client_id and client_secret to be form url encoded.
-So check [Client Secret Basic Auth Method](/docs/apis/openidoauth/authn-methods#client-secret-basic) on how to build it correctly.
+So check [Client Secret Basic Auth Method](/docs/apis/openidoauth/authn-methods#client-secret-basic) for instructions about how to build it correctly.
 
 ```curl
 curl --request POST \

--- a/docs/docs/guides/authentication/authmethods/basic.mdx
+++ b/docs/docs/guides/authentication/authmethods/basic.mdx
@@ -10,11 +10,11 @@ If you need to distinguish different environments, we recommend using multiple p
 
 ## Auth Request
 
-To initialize the user authentication, create an authorization request using HTTP GET in the user agent (browser) to `/authorize`.
+To initialize the user authentication, create an authorization request to `/authorize`, using the HTTP GET method in the user agent (browser).
 The request needs at least the following parameters:
 
 - `client_id`: how the authorization server knows which application it is. Copy from Console.
-- `redirect_uri`: where the authorization code is sent to after the user authentication. Must be one of the registered URIs in the previous step.
+- `redirect_uri`: where the authorization code is sent to after user authentication. Must be one of the registered URIs in the previous step.
 - `response_type`: whether you want to have a code (authorization code flow) or a token (implicit flow). Whenever possible, use `code`
 - `scope`: what scope you want to grant to the access_token / id_token, minimum is `openid`. If you're unsure what you need, you might start with `openid profile email`
 

--- a/docs/docs/guides/authentication/authmethods/implicit.mdx
+++ b/docs/docs/guides/authentication/authmethods/implicit.mdx
@@ -1,37 +1,41 @@
 :::caution Security Notice
 In contrast to the Code Flow, where you'll receive a code for token exchange, with the implicit flow you'll receive
 the tokens directly from the authorization endpoint. This is unsecure and might lead to token leakage and replay attacks.
-It will further be removed in OAuth 2.1 for the exact same reason.
+For this exact reason, OAuth 2.1 will remove implicit flow.
 
 We therefore discourage the use of Implicit Flow and do not cover the flow in this guide.
 :::
 
-If you still need to rely on the implicit flow, simply keep in mind that the response on the authorization_endpoint is
-the same you would be given on the token_endpoint and check the [OAuth / OIDC endpoint documentation](/docs/apis/openidoauth/endpoints) for more information.
+If you still need to rely on implicit flow, note that the `authorization_endpoint` gives the same response that the `token_endpoint`does.
+Check the [OAuth / OIDC endpoint documentation](/docs/apis/openidoauth/endpoints) for more information.
 
 #### redirect_uri
 
-After selecting the authentication method, you can register a redirect_uri and post_logout_redirect_uri.
-The redirect_uri will be called after user authentication for code exchange.
+After selecting the authentication method, you can register a `redirect_uri` and `post_logout_redirect_uri`.
+After the user authenticates, the `redirect_uri` is called for code exchange.
 
-You can even register multiple, but typically one will be enough. If you need to distinguish between different scenarios
-or environments we recommend using the `state` parameter for the former and multiple projects for the latter.
+Typically one `redirect_uri` is enough, but you can have multiple.
+If you need to distinguish between different scenarios,
+we recommend using the `state` parameter.
+If you need to distinguish different environments, we recommend using multiple projects.
 
 ## Auth Request
 
-To initialize the user authentication, you will have to create an authorization request using HTTP GET in the user agent (browser)
-on /authorize with at least the following parameters:
+To initialize the user authentication, create an authorization request to `/authorize`, using the HTTP GET method in the user agent (browser).
+The request needs at least the following parameters:
 
-- `client_id`: this tells the authorization server which application it is, copy from Console
-- `redirect_uri`: where the authorization code is sent to after the user authentication, must be one of the registered in the previous step
-- `response_type`: if you want to have a code (authorization code flow) or directly a token (implicit flow), so when ever possible use `code`
-- `scope`: what scope you want to grant to the access_token / id_token, minimum is `openid`, if you're unsure what you need you might start with `openid profile email`
+- `client_id`: how the authorization server knows which application it is. Copy from Console.
+- `redirect_uri`: where the authorization code is sent to after user authentication. Must be one of the registered URIs in the previous step.
+- `response_type`: whether you want to have a code (authorization code flow) or a token (implicit flow). Whenever possible, use `code`
+- `scope`: what scope you want to grant to the access_token / id_token, minimum is `openid`. If you're unsure what you need, you might start with `openid profile email`
 
-When using the Implicit Flow you will also have to provide a `nonce` parameter to bind the client session to the id_token and to mitigate replay attacks. Furthermore, we recommend using a `state` parameter, which enables you to transfer a state through the authentication process.
+When using the Implicit Flow, provide a `nonce` parameter to bind the client session to the `id_token` and to mitigate replay attacks.
+Furthermore, we recommend using a `state` parameter, which lets
+you to transfer a state through the authentication process.
 
 ### Additional parameters and customization
 
-There are additional parameters and values you can provide to satisfy your use case and to customize the user's authentication flow.
+To customize the user's authentication flow, there are additional parameters and values you can provide to satisfy your use case.
 Please check the [authorization_endpoint reference](/docs/apis/openidoauth/endpoints#authorization_endpoint) in the OAuth / OIDC documentation.
 
 ## Callback
@@ -39,11 +43,12 @@ Please check the [authorization_endpoint reference](/docs/apis/openidoauth/endpo
 Regardless of a successful or error response from the authorization_endpoint, the authorization server will call your callback endpoint you provided by the `redirect_uri`.
 
 :::note
-If the redirect_uri is not provided, was not registered or anything other prevents the auth server form returning the response to the client, the error will be display directly to the user on the auth server.
+If no `redirect_uri` is registered, or if anything else prevents the auth server from returning the response to the client,
+the error is displayed directly on the auth server.
 :::
 
-Upon successful authentication you'll be given the `access_token`, `id_token`, `expires_in` and if provided the unmodified `state` parameter, as you would be given from the token_endpoint when using Authorization Code Flow.
+Upon successful authentication, you'll be given the `access_token`, `id_token`, `expires_in` and, if provided, the unmodified `state` parameter, as you would be given from the `token_endpoint` when using Authorization Code Flow.
 
-If a parameter was missing, malformed or any other error occurred, your answer will contain an `error` stating the error type,
-possibly an `error_description` providing some information about the error and its reason and the `state` parameter.
+If a parameter is missing, malformed, or any other error occurred, your answer will contain an `error`.
+This error states the error type, and possibly gives an `error_description`, which provides some information about the error, its reason, and the `state` parameter.
 Check the [error response section](/docs/apis/openidoauth/endpoints#error-response) in the authorization_endpoint reference.

--- a/docs/docs/guides/authentication/authmethods/jwtpk.mdx
+++ b/docs/docs/guides/authentication/authmethods/jwtpk.mdx
@@ -1,25 +1,29 @@
 #### redirect_uri
 
-After selecting the authentication method, you can register a redirect_uri and post_logout_redirect_uri.
-The redirect_uri will be called after user authentication for code exchange.
+After selecting the authentication method, you can register a `redirect_uri` and `post_logout_redirect_uri`.
+After the user authenticates, the `redirect_uri` is called for code exchange.
 
-You can even register multiple, but typically one will be enough. If you need to distinguish between different scenarios
-or environments we recommend using the `state` parameter for the former and multiple projects for the latter.
+Typically one `redirect_uri` is enough, but you can have multiple.
+If you need to distinguish between different scenarios,
+we recommend using the `state` parameter.
+If you need to distinguish different environments, we recommend using multiple projects.
 
 ## Auth Request
 
-To initialize the user authentication, you will have to create an authorization request using HTTP GET in the user agent (browser)
-on /authorize with at least the following parameters:
+To initialize the user authentication, create an authorization request to `/authorize`, using the HTTP GET method in the user agent (browser).
+The request needs at least the following parameters:
 
-- `client_id`: this tells the authorization server which application it is, copy from Console
-- `redirect_uri`: where the authorization code is sent to after the user authentication, must be one of the registered in the previous step
-- `response_type`: if you want to have a code (authorization code flow) or directly a token (implicit flow), so when ever possible use `code`
-- `scope`: what scope you want to grant to the access_token / id_token, minimum is `openid`, if you're unsure what you need you might start with `openid profile email`
+- `client_id`: how the authorization server knows which application it is. Copy from Console.
+- `redirect_uri`: where the authorization code is sent to after user authentication. Must be one of the registered URIs in the previous step.
+- `response_type`: whether you want to have a code (authorization code flow) or a token (implicit flow). Whenever possible, use `code`
+- `scope`: what scope you want to grant to the access_token / id_token, minimum is `openid`. If you're unsure what you need, you might start with `openid profile email`
 
-We recommend always using two additional parameters `state` and `nonce`. The former enables you to transfer a state through
-the authentication process. The latter is used to bind the client session with the id_token and to mitigate replay attacks.
+We recommend always using two additional parameters: `state` and `nonce`.
+`State` lets you to transfer a state through the authentication process.
+`Nonce` is used to bind the client session with the `id_token`, and to mitigate replay attacks.
 
-You don't need any additional parameter for this request. We're identifying the app by the `client_id` parameter.
+You don't need any additional parameters for this request.
+We identify the app by the `client_id` parameter.
 
 So your request might look like this (linebreaks and whitespace for display reasons):
 

--- a/docs/docs/guides/authentication/authmethods/jwtpk.mdx
+++ b/docs/docs/guides/authentication/authmethods/jwtpk.mdx
@@ -34,37 +34,39 @@ curl --request GET \
 
 ### Additional parameters and customization
 
-There are additional parameters and values you can provide to satisfy your use case and to customize the user's authentication flow.
+To customize the user's authentication flow, there are additional parameters and values you can provide to satisfy your use case.
 Please check the [authorization_endpoint reference](/docs/apis/openidoauth/endpoints#authorization_endpoint) in the OAuth / OIDC documentation.
 
 ## Callback
 
-Regardless of a successful or error response from the authorization_endpoint, the authorization server will call your
-callback endpoint you provided by the `redirect_uri`.
+No matter whether the `authorization_endpoint` response returns a success message or an error,
+the authorization server will call the callback endpoint that you provided in the `redirect_uri`.
 
 :::note
-If the redirect_uri is not provided, was not registered or anything other prevents the auth server form returning the response to the client,
-the error will be display directly to the user on the auth server.
+If no `redirect_uri` is registered, or if anything else prevents the auth server from returning the response to the client,
+the error is displayed directly on the auth server.
 :::
 
-Upon successful authentication you'll be given a `code` and if provided the unmodified `state` parameter.
+Upon successful authentication, you'll be given a `code` and, if provided, the unmodified `state` parameter.
 You will need this `code` in the token request.
 
-If a parameter was missing, malformed or any other error occurred, your answer will contain an `error` stating the error type,
-possibly an `error_description` providing some information about the error and its reason and the `state` parameter.
+If a parameter is missing, malformed, or any other error occurred, your answer will contain an `error`.
+This error states the error type, and possibly gives an `error_description`, which provides some information about the error, its reason, and the `state` parameter.
 Check the [error response section](/docs/apis/openidoauth/endpoints#error-response) in the authorization_endpoint reference.
 
 ## Token request
 
-Next you will have to exchange the given `code` for the tokens. For this HTTP POST request (form-urlencoded) you will need to provide the following:
+Next you need to exchange the given `code` for the tokens.
+For this HTTP POST request (form-urlencoded), you need to provide the following:
 
-- code: the code that was issued from the authorization request
-- grant_type: must be `authorization_code`
-- redirect_uri: callback uri where the code was sent to. Must match exactly the redirect_uri of the authorization request
+- `code`: the code that was issued from the authorization request
+- `grant_type`: must be `authorization_code`
+- `redirect_uri`: callback URI where the code was sent to. Must match exactly the `redirect_uri` of the authorization request
 
 Depending on your authentication method you'll need additional headers and parameters:
 
-Send a JWT in the `client_assertion` and set the `client_assertion_type` to `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`
+Send a JWT in the `client_assertion`.
+Set the `client_assertion_type` to `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`
 for us to validate the signature against the registered public key:
 
 ```curl

--- a/docs/docs/guides/authentication/authmethods/pkce.mdx
+++ b/docs/docs/guides/authentication/authmethods/pkce.mdx
@@ -1,35 +1,42 @@
 #### redirect_uri
 
-After selecting the authentication method, you can register a redirect_uri and post_logout_redirect_uri.
-The redirect_uri will be called after user authentication for code exchange.
+After selecting the authentication method, you can register a `redirect_uri` and `post_logout_redirect_uri`.
+After the user authenticates, the `redirect_uri` is called for code exchange.
 
-You can even register multiple, but typically one will be enough. If you need to distinguish between different scenarios
-or environments we recommend using the `state` parameter for the former and multiple projects for the latter.
+Typically one `redirect_uri` is enough, but you can have multiple.
+If you need to distinguish between different scenarios,
+we recommend using the `state` parameter.
+If you need to distinguish different environments, we recommend using multiple projects.
 
 ## Auth Request
 
-To initialize the user authentication, you will have to create an authorization request using HTTP GET in the user agent (browser)
-on /authorize with at least the following parameters:
+To initialize the user authentication, create an authorization request to `/authorize`, using the HTTP GET method in the user agent (browser).
+The request needs at least the following parameters:
 
-- `client_id`: this tells the authorization server which application it is, copy from Console
-- `redirect_uri`: where the authorization code is sent to after the user authentication, must be one of the registered in the previous step
-- `response_type`: if you want to have a code (authorization code flow) or directly a token (implicit flow), so when ever possible use `code`
-- `scope`: what scope you want to grant to the access_token / id_token, minimum is `openid`, if you're unsure what you need you might start with `openid profile email`
+- `client_id`: how the authorization server knows which application it is. Copy from Console.
+- `redirect_uri`: where the authorization code is sent to after user authentication. Must be one of the registered URIs in the previous step.
+- `response_type`: whether you want to have a code (authorization code flow) or a token (implicit flow). Whenever possible, use `code`
+- `scope`: what scope you want to grant to the access_token / id_token, minimum is `openid`. If you're unsure what you need, you might start with `openid profile email`
 
-We recommend always using two additional parameters `state` and `nonce`. The former enables you to transfer a state through
-the authentication process. The latter is used to bind the client session with the id_token and to mitigate replay attacks.
+We recommend always using two additional parameters: `state` and `nonce`.
+`State` lets you to transfer a state through the authentication process.
+`Nonce` is used to bind the client session with the `id_token`, and to mitigate replay attacks.
 
-PKCE stands for Proof Key for Code Exchange. So other than "normal" code exchange, the does not authenticate using
-client_id and client_secret but an additional code. You will have to generate a random string, hash it and send this hash
-on the authorization_endpoint. On the token_endpoint you will then send the plain string for the authorization to compute
-the hash as well and to verify it's correct. In order to do so you're required to send the following two parameters as well:
+
+PKCE stands for __Proof Key for Code Exchange_.
+So other than "normal" code exchange, it does not authenticate using
+`client_id` and `client_secret`, but through an additional code.
+You will have to generate a random string, hash it and send this hash
+to the `authorization_endpoint`.
+Then send the plain string to the `token_endpoint` for the authorization to compute the hash to verify it matches.
+In order to do so, you're required to send the following two parameters as well:
 
 - `code_challenge`: the base64url representation of the (sha256) hash of your random string
-- `code_challenge_method`: must always be `S256` standing for sha256, this is the only algorithm we support
+- `code_challenge_method`: must be `S256`. Standing for sha256, this is the only algorithm we support
 
-For example for `random-string` the code_challenge would be `9az09PjcfuENS7oDK7jUd2xAWRb-B3N7Sr3kDoWECOY`
+For example for `random-string`, the `code_challenge` would be `9az09PjcfuENS7oDK7jUd2xAWRb-B3N7Sr3kDoWECOY`
 
-The request would finally look like (linebreaks and whitespace for display reasons):
+The request would finally look like this (linebreaks and whitespace for display reasons):
 
 ```curl
 curl --request GET \
@@ -44,33 +51,34 @@ curl --request GET \
 
 ### Additional parameters and customization
 
-There are additional parameters and values you can provide to satisfy your use case and to customize the user's authentication flow.
+To customize the user's authentication flow, there are additional parameters and values you can provide to satisfy your use case.
 Please check the [authorization_endpoint reference](/docs/apis/openidoauth/endpoints#authorization_endpoint) in the OAuth / OIDC documentation.
 
 ## Callback
 
-Regardless of a successful or error response from the authorization_endpoint, the authorization server will call your
-callback endpoint you provided by the `redirect_uri`.
+No matter whether the `authorization_endpoint` response returns a success message or an error,
+the authorization server will call the callback endpoint that you provided in the `redirect_uri`.
 
 :::note
-If the redirect_uri is not provided, was not registered or anything other prevents the auth server form returning the response to the client,
-the error will be display directly to the user on the auth server.
+If no `redirect_uri` is registered, or if anything else prevents the auth server from returning the response to the client,
+the error is displayed directly on the auth server.
 :::
 
-Upon successful authentication you'll be given a `code` and if provided the unmodified `state` parameter.
+Upon successful authentication, you'll be given a `code` and, if provided, the unmodified `state` parameter.
 You will need this `code` in the token request.
 
-If a parameter was missing, malformed or any other error occurred, your answer will contain an `error` stating the error type,
-possibly an `error_description` providing some information about the error and its reason and the `state` parameter.
+If a parameter is missing, malformed, or any other error occurred, your answer will contain an `error`.
+This error states the error type, and possibly gives an `error_description`, which provides some information about the error, its reason, and the `state` parameter.
 Check the [error response section](/docs/apis/openidoauth/endpoints#error-response) in the authorization_endpoint reference.
 
 ## Token request
 
-Next you will have to exchange the given `code` for the tokens. For this HTTP POST request (form-urlencoded) you will need to provide the following:
+Next you need to exchange the given `code` for the tokens.
+For this HTTP POST request (form-urlencoded), you need to provide the following:
 
-- code: the code that was issued from the authorization request
-- grant_type: must be `authorization_code`
-- redirect_uri: callback uri where the code was sent to. Must match exactly the redirect_uri of the authorization request
+- `code`: the code that was issued from the authorization request
+- `grant_type`: must be `authorization_code`
+- `redirect_uri`: callback URI where the code was sent to. Must match exactly the `redirect_uri` of the authorization request
 
 Depending on your authentication method you'll need additional headers and parameters:
 

--- a/docs/docs/guides/authentication/authmethods/pkcenative.mdx
+++ b/docs/docs/guides/authentication/authmethods/pkcenative.mdx
@@ -1,51 +1,54 @@
 #### redirect_uri
 
-Native clients might have to register multiple redirect_uris as operating system have different requirements.
-Typically, you register a redirect_uri starting with a custom protocol, e.g. `ch.zitadel.app://callback`.
+Native clients might have to register multiple `redirect_uris`, as operating system have different requirements.
+Typically, you register a `redirect_uri` starting with a custom protocol, e.g. `ch.zitadel.app://callback`.
 You're also allowed to use http://localhost, http://127.0.0.1 and http:[::1] without specifying a port: `http://locahost/callback`.
 
 #### post creation actions
 
-After the application creation, you might want to set additional options like `refresh_token` and `additional origins`.
+After you create the application, you might want to set additional options like `refresh_token` and `additional origins`.
 
-If you want to request refresh_tokens and use them to renew the user's access_tokens without their interaction,
+If you want to request `refresh_tokens` and use them to renew the user's `access_tokens` without their interaction,
 enable them in the OIDC Configuration section by ticking the checkbox.
 
-When calling the userinfo_endpoint or any ZITADEL API, we will check if an origin header is sent. This is automatically done
-by the user agent. If one is sent we will check if the origin is allowed for your application. By default, all computed
-origins of the redirect_uri list are allowed.
-So if your native app is built with a JavaScript base framework like ReactNative and you only specified redirect_uris
-with a custom protocol, you will need to add the origin where the app is served from, e.g. `http://localhost:8100`.
+When you call the `userinfo_endpoint`, or any ZITADEL API, we check whether an origin header is sent.
+The user agent does this automatically.
+If an origin header is sent, we check whether the origin is allowed for your application.
+By default, all computed origins of the `redirect_uri` list are allowed.
+So if your native app is built with a JavaScript base framework, like ReactNative, and you specified only a `redirect_uri`
+with a custom protocol, you need to add the origin where the app is served from, e.g. `http://localhost:8100`.
 
 ### Additional parameters and customization
 
-There are additional parameters and values you can provide to satisfy your use case and to customize the user's authentication flow.
+To customize the user's authentication flow, there are additional parameters and values you can provide to satisfy your use case.
 Please check the [authorization_endpoint reference](/docs/apis/openidoauth/endpoints#authorization_endpoint) in the OAuth / OIDC documentation.
+
 
 ## Callback
 
-Regardless of a successful or error response from the authorization_endpoint, the authorization server will call your
-callback endpoint you provided by the `redirect_uri`.
+No matter whether the `authorization_endpoint` response returns a success message or an error,
+the authorization server will call the callback endpoint that you provided in the `redirect_uri`.
 
 :::note
-If the redirect_uri is not provided, was not registered or anything other prevents the auth server form returning the response to the client,
-the error will be display directly to the user on the auth server.
+If no `redirect_uri` is registered, or if anything else prevents the auth server from returning the response to the client,
+the error is displayed directly on the auth server.
 :::
 
-Upon successful authentication you'll be given a `code` and if provided the unmodified `state` parameter.
+Upon successful authentication, you'll be given a `code` and, if provided, the unmodified `state` parameter.
 You will need this `code` in the token request.
 
-If a parameter was missing, malformed or any other error occurred, your answer will contain an `error` stating the error type,
-possibly an `error_description` providing some information about the error and its reason and the `state` parameter.
+If a parameter is missing, malformed, or any other error occurred, your answer will contain an `error`.
+This error states the error type, and possibly gives an `error_description`, which provides some information about the error, its reason, and the `state` parameter.
 Check the [error response section](/docs/apis/openidoauth/endpoints#error-response) in the authorization_endpoint reference.
 
 ## Token request
 
-Next you will have to exchange the given `code` for the tokens. For this HTTP POST request (form-urlencoded) you will need to provide the following:
+Next you need to exchange the given `code` for the tokens.
+For this HTTP POST request (form-urlencoded), you need to provide the following:
 
-- code: the code that was issued from the authorization request
-- grant_type: must be `authorization_code`
-- redirect_uri: callback uri where the code was sent to. Must match exactly the redirect_uri of the authorization request
+- `code`: the code that was issued from the authorization request
+- `grant_type`: must be `authorization_code`
+- `redirect_uri`: callback URI where the code was sent to. Must match exactly the `redirect_uri` of the authorization request
 
 Depending on your authentication method you'll need additional headers and parameters:
 

--- a/docs/docs/guides/authentication/authmethods/pkcenative.mdx
+++ b/docs/docs/guides/authentication/authmethods/pkcenative.mdx
@@ -1,6 +1,6 @@
 #### redirect_uri
 
-Native clients might have to register multiple `redirect_uris`, as operating system have different requirements.
+Native clients might have to register more than one `redirect_uri`, as operating system have different requirements.
 Typically, you register a `redirect_uri` starting with a custom protocol, e.g. `ch.zitadel.app://callback`.
 You're also allowed to use http://localhost, http://127.0.0.1 and http:[::1] without specifying a port: `http://locahost/callback`.
 

--- a/docs/docs/guides/authentication/identity-brokering.md
+++ b/docs/docs/guides/authentication/identity-brokering.md
@@ -14,7 +14,7 @@ title: Identity Brokering
             <ul>
                 <li>Learn about Identity Providers</li>
                 <li>Add a new identity provider</li>
-                <li>Example with Google Login</li>
+                <li>See an example with Google Login</li>
             </ul>
         </td>
     </tr>
@@ -30,27 +30,29 @@ title: Identity Brokering
 
 ## What is Identity Brokering and Federated Identities?
 
-Federated identity management is an arrangement built upon the trust between two or more domains. Users of these domains are allowed to access applications and services using the same identity.
-This identity is known as federated identity and the pattern behind this as identity federation.
+_Federated identity management_ is an arrangement built upon the trust between two or more domains.
+Users of these domains can access applications and services using the same identity.
+This identity is known as _federated identity_.
+The pattern behind it is known as _identity federation_.
 
-A service provider that specializes in brokering access control between multiple service providers (also referred to as relying parties) is called identity broker.
-Federated identity management is an arrangement that is made between two or more such identity brokers across organizations.
+An _identity broker_ is a service provider that specializes in brokering access control between multiple service providers (also referred to as relying parties).
+_Federated identity management_ is an arrangement that is made between two or more such identity brokers across organizations.
 
-Example:
-If Google is configured as identity provider on your organization, the user will get the option to use his Google Account on the Login Screen of ZITADEL (1).
-ZITADEL will redirect the user to the login screen of Google where he as to authenticated himself (2) and is sent back after he has finished that (3).
-Because Google is registered as trusted identity provider the user will be able to login in with the Google account after he linked an existing ZITADEL Account or just registered a new one with the claims provided by Google (4)(5).
+For example,
+if Google is configured as an identity provider on your organization, users can use their Google Account on the Login Screen of ZITADEL (1).
+ZITADEL redirects users to the login screen of Google, where they authenticate themselves, (2) and are sent back (3).
+Because Google is registered as a trusted identity provider, users can login in with the Google account after they link an existing ZITADEL Account, or after they register a new one with the claims provided by Google (4)(5).
 
 ![Identity Brokering](/img/guides/identity_brokering.png)
 
 ## Exercise: Register an external identity provider
 
-In this exercise we will add a new Google identity provider to federate identities with ZITADEL.
+In this exercise, we will add a new Google identity provider to federate identities with ZITADEL.
 
 ### 1. Create new OIDC Client
 
-1. Register an OIDC Client in your preferred provider
-2. Make sure you add the ZITADEL callback redirect uris
+1. Register an OIDC Client in your preferred provider.
+2. Make sure you add the ZITADEL callback redirect uris.
    https://accounts.zitadel.ch/register/externalidp/callback
    https://accounts.zitadel.ch/login/externalidp/callback
 
@@ -59,45 +61,48 @@ In this exercise we will add a new Google identity provider to federate identiti
 Google Example:
 
 1. Go to the Google Gloud Platform and choose youre project: <https://console.cloud.google.com/apis/credentials>
-2. Click on "+ CREATE CREDENTIALS" and choose "OAuth client ID"
-3. Choose Web application as Application type and give a name
-4. Add the redirect uris from above
-5. Save clientid and client secret
+2. Select **+ CREATE CREDENTIALS**. Choose **OAuth client ID**.
+3. Choose **Web application** as the Application type and give it a name.
+4. Add the redirect uris from above.
+5. Save the `clientid` and client secret.
 
 ![Add new oAuth credentials in Google Console](/img/google_add_credentials.gif)
 
 ### 2. Add custom login policy on your organization
 
-1. Go to your organization settings by clicking on "Organization" in the menu or using the following link: <https://console.zitadel.ch/org>
-2. Modify your login policy
-3. As long as you have the default policy, you can't change the policy. Click create custom policy to set your on settings.
+1. Go to your organization settings by selecting **Organization** in the menu, or by following this link: <https://console.zitadel.ch/org>.
+2. Modify your login policy.
+3. As long as you have the default policy, you can't change the policy. To set your own settings, select **create custom**.
 
 ![Add custom login policy](/img/console_org_custom_login_policy.gif)
 
 ### 3.Configure new identity provider
 
-1. Go to the identity providers section and click new
-2. Fill out the form
-   - Use the issuer, clientid and client secret provided by your provider
-   - The scopes will be prefilled with openid, profile and email, because this information is relevant for ZITADEL
-   - You can choose what fields you like to map as the display name and as username. The fields you can choose are preferred_username and email
-     (Example: For Google you should choose email for both fields)
+1. Go to the identity providers section. Select **new**.
+2. Fill out the form:
+   - Use the issuer, `clientid` and client secret provided by your provider
+   - The scopes will be prefilled with `openid`, profile and email, because this information is relevant for ZITADEL.
+   - Choose what fields you like to map as the display name and username. The fields you can choose are `preferred_username` and `email`
+     (Example: For Google, you should choose `email` for both fields)
 3. Save your configuration
-4. Link your new configuration to your login policy. By searching in the organization category you will get you own configuration. If you choose system you can link all predefined providers.
+4. Link your new configuration to your login policy.
+   Search the organization category to get your own configuration.
+   If you choose system you can link all predefined providers.
 
 ![Configure identity provider](/img/console_org_identity_provider.gif)
 
 ### 4.Send the primary domain scope on the authorization request
-ZITADEL will show a set of identity providers by default. This configuration can be changed by users with the [manager role] (https://docs.zitadel.ch/docs/concepts/zitadel/objects/managers) `IAM_OWNER`.
+ZITADEL shows a set of identity providers by default. This configuration can be changed by users with the [manager role] (https://docs.zitadel.ch/docs/concepts/zitadel/objects/managers) `IAM_OWNER`.
 
-An organization's login settings will be shown 
+An organization's login settings are shown:
 
-- as soon as the user has entered the loginname and ZITADEL can identitfy to which organization he belongs; or
+- as soon as users enter the `loginname`, and ZITADEL can identify which organizations they belong to; or
 - by sending a primary domain scope.
-To get your own configuration you will have to send the [primary domain scope](https://docs.zitadel.ch/docs/apis/openidoauth/scopes#reserved-scopes) in your [authorization request](https://docs.zitadel.ch/docs/guides/authentication/login-users/#auth-request) .
-The primary domain scope will restrict the login to your organization, so only users of your own organization will be able to login, also your branding and policies will trigger.
+To get your own configuration, send the [primary domain scope](https://docs.zitadel.ch/docs/apis/openidoauth/scopes#reserved-scopes) in your [authorization request](https://docs.zitadel.ch/docs/guides/authentication/login-users/#auth-request) .
+The primary domain scope restricts the login to your organization, so only users of your own organization can login.
+This also triggers your branding and policies.
 
-See the following link as an example. Users will be able to register and login to the organization that verified the @caos.ch domain only.
+See the following link as an example. Users can register and login to the organization that verified the `@caos.ch` domain only.
 ```
 https://accounts.zitadel.ch/oauth/v2/authorize?client_id=69234247558357051%40zitadel&scope=openid%20profile%20urn%3Azitadel%3Aiam%3Aorg%3Adomain%3Aprimary%3Acaos.ch&redirect_uri=https%3A%2F%2Fconsole.zitadel.ch%2Fauth%2Fcallback&state=testd&response_type=code&nonce=test&code_challenge=UY30LKMy4bZFwF7Oyk6BpJemzVblLRf0qmFT8rskUW0
 ```
@@ -110,11 +115,13 @@ Make sure to replace the domain `caos.ch` with your own domain to trigger the co
 
 :::caution
 
-This example uses the ZITADEL Cloud Application for demonstration. You need to create your own auth request with your applications parameters. Please see the docs to construct an [Auth Request](https://docs.zitadel.ch/docs/guides/authentication/login-users/#auth-request).
+This example uses the ZITADEL Cloud Application for demonstration.
+You need to create your own auth request with your applications parameters.
+Please see the docs to construct an [Auth Request](https://docs.zitadel.ch/docs/guides/authentication/login-users/#auth-request).
 
 :::
 
-Your user will now be able to choose Google for login instead of username/password or mfa.
+Your user now can choose Google to login instead of username/password or mfa.
 
 ## Knowledge Check
 
@@ -132,7 +139,7 @@ Your user will now be able to choose Google for login instead of username/passwo
 
 * The issuer for your identity provider is https://issuer.zitadel.ch
     - [ ] yes
-    - [x] no (The issuer is provided by your choosen identity provider. In the case of Google it's https://accounts.google.com)
+    - [x] no (The issuer is provided by your chosen identity provider. In the case of Google, it's https://accounts.google.com)
 * The identity provider has to be oAuth 2.0 compliant
     - [x] yes
     - [ ] no
@@ -141,8 +148,8 @@ Your user will now be able to choose Google for login instead of username/passwo
 
 ## Summary
 
-* You can federate identities of all oAuth 2.0 compliant external identity providers
-* Configure the provider in your custom login policy
+* You can federate identities of all oAuth 2.0 compliant external identity providers.
+* Configure the provider in your custom login policy.
 
 Where to go from here:
 

--- a/docs/docs/guides/authentication/login-users.mdx
+++ b/docs/docs/guides/authentication/login-users.mdx
@@ -38,7 +38,7 @@ The following diagram demonstrates a basic authorization_code flow:
 3. The Authorization Server (ZITADEL) sends an HTTP `302` to the user's browser, which redirects the user to the login UI.
 4. The user has to authenticate using the demanded auth mechanics.
 5. Your application calls on the registered callback path (`redirect_uri`) and will be provided an `authorization_code`.
-6. This `authorization_code` must then be sent together with your application's authentication (`client_id` + `client_secret`) to the token endpoint).
+6. This `authorization_code` must then be sent together with your application's authentication (`client_id` + `client_secret`) to the token endpoint.
 7. In exchange, the Authorization Server (ZITADEL) returns an `access_token`, and, if requested, a `refresh_token`. In the case of OIDC, it returns an id_token as well.
 8. The `access_token` can then be used to call a Resource Server (API). The token is be sent as an Authorization Header.
 

--- a/docs/docs/guides/authentication/login-users.mdx
+++ b/docs/docs/guides/authentication/login-users.mdx
@@ -64,7 +64,7 @@ This starts a wizard, asking you for an application name and a type.
 >
 <TabItem value="web">
 
-#### Authentication method
+### Authentication method
 
 After selecting WEB, choose an authentication method. We recommend using PKCE.
 For even better security, you could switch to JWT, or just rely on the standard Code Flow.

--- a/docs/docs/guides/authentication/login-users.mdx
+++ b/docs/docs/guides/authentication/login-users.mdx
@@ -37,8 +37,8 @@ The following diagram demonstrates a basic authorization_code flow:
 2. You create an authorization request to the authorization endpoint.
 3. The Authorization Server (ZITADEL) sends an HTTP `302` to the user's browser, which redirects the user to the login UI.
 4. The user has to authenticate using the demanded auth mechanics.
-5. Your application calls on the registered callback path (redirect_uri) and will be provided an authorization_code.
-6. This authorization_code must then be sent together with your applications authentication (`client_id` + `client_secret`) to the token endpoint_.
+5. Your application calls on the registered callback path (`redirect_uri`) and will be provided an `authorization_code`.
+6. This `authorization_code` must then be sent together with your application's authentication (`client_id` + `client_secret`) to the token endpoint).
 7. In exchange, the Authorization Server (ZITADEL) returns an `access_token`, and, if requested, a `refresh_token`. In the case of OIDC, it returns an id_token as well.
 8. The `access_token` can then be used to call a Resource Server (API). The token is be sent as an Authorization Header.
 

--- a/docs/docs/guides/authentication/login-users.mdx
+++ b/docs/docs/guides/authentication/login-users.mdx
@@ -78,7 +78,7 @@ This improves how the wizard guides you through the process:
 
 <TabItem value="native">
 
-#### Authentication method
+### Authentication method
 
 When selecting Native, the authentication method always needs to be PKCE.
 

--- a/docs/docs/guides/authentication/login-users.mdx
+++ b/docs/docs/guides/authentication/login-users.mdx
@@ -64,7 +64,7 @@ This starts a wizard, asking you for an application name and a type.
 >
 <TabItem value="web">
 
-### Authentication method
+### Web authentication methods
 
 After selecting WEB, choose an authentication method. We recommend using PKCE.
 For even better security, you could switch to JWT, or just rely on the standard Code Flow.
@@ -78,7 +78,7 @@ This improves how the wizard guides you through the process:
 
 <TabItem value="native">
 
-### Authentication method
+### Native authentication method
 
 When selecting Native, the authentication method always needs to be PKCE.
 
@@ -87,7 +87,7 @@ When selecting Native, the authentication method always needs to be PKCE.
 
 <TabItem value="spa">
 
-### Authentication method
+### SPA authentication methods
 
 When selecting SPA, the recommended authentication method is again PKCE.
 All common Frameworks, like Angular, React, Vue.js, can successfully authenticate with PKCE.

--- a/docs/docs/guides/authentication/login-users.mdx
+++ b/docs/docs/guides/authentication/login-users.mdx
@@ -1,5 +1,5 @@
 ---
-title: Login Users into your Application
+title: Authenticate your application's users
 ---
 
 import Tabs from "@theme/Tabs";
@@ -8,23 +8,24 @@ import AuthMethods from "./authmethods.mdx";
 
 ## Overview
 
-This guide will show you how to use ZITADEL to login users into your application (authentication).
-It will guide you step-by-step through the basics and point out on how to customize process.
+This guide shows you how to use ZITADEL to *authenticate* your app's users.
+That is, it shows you how to use ZITADEL to log users in to your app.
+It guides you step-by-step through the basics and points out on how to customize the process.
 
 ## OIDC / OAuth Flow
 
-OAuth and therefore OIDC know three different application types:
+OAuth (and therefore OIDC) recognize three different application types:
 
 - Web (Server-side web applications such as java, .net, ...)
-- Native (native, mobile or desktop applications)
+- Native (native, mobile, or desktop applications)
 - User Agent (single page applications / SPA, generally JavaScript executed in the browser)
 
-Depending on the app type you're trying to register, there are small differences.
-But regardless of the app type we recommend using Proof Key for Code Exchange (PKCE).
+Depending on the app type you're trying to register, there are small process differences.
+Regardless of the type you use, we recommend  *Proof Key for Code Exchange (PKCE)*.
+The [Recommended Authorization Flows](../authorization/oauth-recommended-flows#different-client-profiles)
+page explains why we recommend PKCE.
 
-Please read the following guide about the [different-client-profiles](../authorization/oauth-recommended-flows#different-client-profiles) and why to use PKCE.
-
-### Code Flow
+### About the authorization code flow
 
 For a basic understanding of OAuth and its flows, we'll briefly describe the most important flow: **Authorization Code**.
 
@@ -32,24 +33,25 @@ The following diagram demonstrates a basic authorization_code flow:
 
 ![Authorization Code Flow](/img/guides/auth_flow.png)
 
-1. When an unauthenticated user visits your application,
-2. you will create an authorization request to the authorization endpoint.
-3. The Authorization Server (ZITADEL) will send an HTTP 302 to the user's browser, which will redirect him to the login UI.
-4. The user will have to authenticate using the demanded auth mechanics.
-5. Your application will be called on the registered callback path (redirect_uri) and be provided an authorization_code.
-6. This authorization_code must then be sent together with you applications authentication (client_id + client_secret) to the token_endpoint
-7. In exchange the Authorization Server (ZITADEL) will return an access_token and if requested a refresh_token and in the case of OIDC an id_token as well
-8. The access_token can then be used to call a Resource Server (API). The token will be sent as Authorization Header.
+1. An unauthenticated user visits your application.
+2. You create an authorization request to the authorization endpoint.
+3. The Authorization Server (ZITADEL) sends an HTTP `302` to the user's browser, which redirects the user to the login UI.
+4. The user has to authenticate using the demanded auth mechanics.
+5. Your application calls on the registered callback path (redirect_uri) and will be provided an authorization_code.
+6. This authorization_code must then be sent together with your applications authentication (`client_id` + `client_secret`) to the token endpoint_.
+7. In exchange, the Authorization Server (ZITADEL) returns an `access_token`, and, if requested, a `refresh_token`. In the case of OIDC, it returns an id_token as well.
+8. The `access_token` can then be used to call a Resource Server (API). The token is be sent as an Authorization Header.
 
 This flow is the same when using PKCE or JWT with Private Key for authentication.
 
 ## Create Application
 
-To create an application, open your project in Console and start by clicking on the "New" button in the Application section.
+To create an application:
 
-#### Application type
+1. Open your project in Console
+2. Select the **New** button in the **Application** section.
 
-This will start a wizard asking you for an application name and a type.
+This starts a wizard, asking you for an application name and a type.
 
 <Tabs
     groupId="app-type"
@@ -64,11 +66,12 @@ This will start a wizard asking you for an application name and a type.
 
 #### Authentication method
 
-After selecting WEB, you'll next have to choose an authentication method. As mentioned before we recommend using PKCE.
-For even better security you could switch to JWT or just rely on the standard Code Flow. For security reasons we don't
-recommend using POST and will not cover it in this guide.
+After selecting WEB, choose an authentication method. We recommend using PKCE.
+For even better security, you could switch to JWT, or just rely on the standard Code Flow.
+For security reasons, we don't recommend using POST and do not cover it in this guide.
 
-Please change the authentication method here as well, if you did so in the wizard, so we can better guide you through the process:
+If you changed the authentication method in the wizard, change it here as well.
+This improves how the wizard guides you through the process:
 
 <AuthMethods selected="web" />
 </TabItem>
@@ -77,7 +80,7 @@ Please change the authentication method here as well, if you did so in the wizar
 
 #### Authentication method
 
-When selecting Native the authentication method always needs to be PKCE.
+When selecting Native, the authentication method always needs to be PKCE.
 
 <AuthMethods selected="native" />
 </TabItem>
@@ -86,8 +89,9 @@ When selecting Native the authentication method always needs to be PKCE.
 
 #### Authentication method
 
-When selecting SPA the recommended authentication method is again PKCE. All common Frameworks like Angular, React, Vue.js and so on
-are able to successfully authenticate with PKCE. Our Managament UI Console for instance uses PKCE as well.
+When selecting SPA, the recommended authentication method is again PKCE.
+All common Frameworks, like Angular, React, Vue.js, can successfully authenticate with PKCE.
+Our Managament UI Console, for instance, uses PKCE as well.
 
 <AuthMethods selected="spa" />
 </TabItem>

--- a/docs/docs/guides/authentication/login-users.mdx
+++ b/docs/docs/guides/authentication/login-users.mdx
@@ -87,7 +87,7 @@ When selecting Native, the authentication method always needs to be PKCE.
 
 <TabItem value="spa">
 
-#### Authentication method
+### Authentication method
 
 When selecting SPA, the recommended authentication method is again PKCE.
 All common Frameworks, like Angular, React, Vue.js, can successfully authenticate with PKCE.

--- a/docs/docs/guides/authentication/serviceusers.md
+++ b/docs/docs/guides/authentication/serviceusers.md
@@ -35,9 +35,9 @@ import UserDescription from '../../concepts/structure/_user_description.mdx';
 
 ## Exercise: Create a Service User
 
-1. Navigate to Service Users
-2. Click on **New**
-3. Enter a user name and a display name
+1. Navigate to Service Users.
+2. Click on **New**.
+3. Enter a user name and a display name.
 
 ![Create new service user](/img/console_serviceusers_create.gif)
 
@@ -45,27 +45,32 @@ import UserDescription from '../../concepts/structure/_user_description.mdx';
 
 In ZITADEL we use the `private_jwt` (**“JWT bearer token with private key”**, [RFC7523](https://tools.ietf.org/html/rfc7523)) authorization grant for this non-interactive authentication.
 
-You need to follow these steps to authenticate a service user and receive a access token:
+To authenticate a service user and receive a access token, follow these steps:
 
 1. Generate a private-public key pair in ZITADEL
-2. Create a JSON Web Token (JWT) and sign with private key
+2. Create a JSON Web Token (JWT) and sign with your private key
 3. With this JWT, request an OAuth token from ZITADEL
 
-With this token you can make subsequent requests, just like a human user.
+With this token, you can make subsequent requests, just like a human user.
 
 ## Exercise: Get an access token
 
-In this exercise we will authenticate a service user and receive an access_token to use against a API.
+In this exercise we will authenticate a service user and receive an `access_token` to use against a API.
 
 > **Information:** Are you stuck? Don't hesitate to reach out to us on [Github Discussions](https://github.com/caos/zitadel/discussions) or [contact us](https://zitadel.ch/contact/) privately.
 
 ### 1. Generate a private-public key pair in ZITADEL
 
-Select your service user and in the section KEYS click **New**. Enter an expiration date and click **Add**. Make sure to download the json by clicking **Download**.
+1. Select your service user and in the section KEYS, select **New**.
+1. Enter an expiration date and select **Add**.
+1. Make sure to download the JSON by selecting **Download**.
 
 ![Create private key](/img/console_serviceusers_new_key.gif)
 
-The downloaded json should look something like outlined below. The value of `key` contains the *private* key for your service account. Please make sure to keep this key securely stored and handle with care. The public key is automatically stored in ZITADEL.
+The downloaded json should look something like the following snippet.
+The value of `key` contains the *private* key for your service account.
+Make sure to keep this key securely stored and handle it with care.
+The public key is automatically stored in ZITADEL.
 
 ```json
 {
@@ -115,7 +120,7 @@ If you use Go, you might want to use the [provided tool](https://github.com/caos
 
 ### 3. With this JWT, request an OAuth token from ZITADEL
 
-With the encoded JWT from the prior step, you will need to craft a POST request to ZITADEL's token endpoint:
+With the encoded JWT from the prior step, craft a POST request to ZITADEL's token endpoint:
 
 ```bash
 curl --request POST \
@@ -145,7 +150,7 @@ Content-Type: application/json
 
 ### 4. Verify that you have a valid access token
 
-For this example let's call the userinfo endpoint to verfiy that our access token works.
+For this example, call the `userinfo` endpoint to verfiy that our access token works.
 
 ```bash
 curl --request POST \
@@ -198,9 +203,9 @@ Content-Type: application/json
 
 ## Summary
 
-* With service users you can secure machine-to-machine communication
-* Because there is no interactive logon, you need to use a JWT signed with your private key to authorize the user
-* After successful authorization you can use an access token like for human users
+* With service users, you can secure machine-to-machine communication.
+* Because there is no interactive login, you need to use a JWT signed with your private key to authorize the user.
+* After successful authorization, you can use an access token like you would for human users.
 
 Where to go from here:
 


### PR DESCRIPTION
A summary of the big changes:
- changes the title's verb from "log in" to "authenticate".
  This makes the title more coherent with the section in the sidebar.
- Uses the verb form of "Log in" ("Login" is a noun)
- Avoids future tense, except in sentences with condition
  https://developers.google.com/style/tense
- Breaks sequence into numbered list
  -- This scans better
  -- Even though it's only two items now, the list could grow!

I also would not recommend jumping heading levels (here the tabs go from
h2 to h4), but I didn't change that because I'm not sure how it'll
affect the docs on the rendered page.