### PR TITLE
chore: Adds release notification action

### DIFF
--- a/.github/workflows/release-notification.yaml
+++ b/.github/workflows/release-notification.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test_message:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     
     # Skip in case it's a prerelease
     if: "!github.event.release.prerelease"
@@ -20,8 +20,6 @@ jobs:
       - name: Get release
         id: get_release
         uses: bruceadams/get-release@v1.2.3
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
     
       # Send Webhook to Discord
       - name: Discord Webhook

--- a/.github/workflows/release-notification.yaml
+++ b/.github/workflows/release-notification.yaml
@@ -1,0 +1,33 @@
+# This action sends a notification to discord about new releases
+
+name: Release notification
+
+# Controls when the workflow will run
+on:
+  release:
+    types: [published]
+
+jobs:
+  test_message:
+    runs-on: ubuntu-latest
+    
+    # Skip in case it's a prerelease
+    if: "!github.event.release.prerelease"
+
+    steps:
+
+      # Get the fields for the release
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.2.3
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+    
+      # Send Webhook to Discord
+      - name: Discord Webhook
+        uses: joelwmale/webhook-action@2.1.0
+        with:
+          # The url to send the webhook event to
+          url: '${{ secrets.DISCORD_WH }}'
+          # The data sent to the webhook
+          body: '{ "content": "New release published", "embeds": [ { "title": "${{github.event.release.name}}", "url": "${{steps.get_release.outputs.html_url}}" , "description": ${{toJSON(steps.get_release.outputs.body)}} } ] }'


### PR DESCRIPTION
When a new release is published, then a webhook is sent to discord. Skip pre-releases.