### PR TITLE
docs: edits to guide section

### DIFF
--- a/docs/docs/apis/proto/management.md
+++ b/docs/docs/apis/proto/management.md
@@ -36,7 +36,7 @@ title: zitadel/management.proto
 > **rpc** GetIAM([GetIAMRequest](#getiamrequest))
 [GetIAMResponse](#getiamresponse)
 
-Returns some needed settings of the IAM (Global Organisation ID, Zitadel Project ID)
+Returns some needed settings of the IAM (global organisation ID, ZITADEL project ID)
 
 
 

--- a/docs/docs/concepts/structure/_granted_project_description.mdx
+++ b/docs/docs/concepts/structure/_granted_project_description.mdx
@@ -1,17 +1,23 @@
 ![Organization Grant](/img/concepts/objects/organization_grants.png)
 
-With ZITADEL you can grant selected roles within your project to an organization. The receiving organization can then create authorizations for their users on their own (self-service).
+With ZITADEL you can grant selected roles within your project to an organization.
+The receiving organization can then create authorizations for their users on their own (self-service).
 
-An example could be a service provider that offers a SaaS solution that has different permissions for employees working in Sales and Accounting. As soon as a new client purchases the service, the provider could grant the roles ‘sales’ and ‘accounting’ to that organization, allowing them to self-manage how they want to allocate the roles to their users.
+An example could be a service provider that offers a SaaS solution that has different permissions for employees working in Sales and Accounting.
+As soon as a new client purchases the service, the provider could grant the roles `sales` and `accounting` to that organization,
+allowing them to self-manage how they want to allocate roles to their users.
 
 The process of assigning certain roles by default or according to rules can be further automated by utilizing Service Users in the service provider’s business process.
 
-Obviously, your organization can grant projects and receive projects. When you are granting, then the receiving organization will be displayed in the section GRANTED ORGANIZATIONS of your project.
+Obviously, your organization can grant projects and receive projects.
+When you are granting, then the receiving organization will be displayed in the section GRANTED ORGANIZATIONS of your project.
 
 ![Project granted to organization](/img/console_projects_granted.png)
 
-A granted project, on the other hand, belongs to a third party, granting you some rights to manage certain roles of their project. ZITADEL Console shows granted projects in a dedicated navigation menu, to clearly separate from your organization’s projects.
+A granted project, on the other hand, belongs to a third party, granting you some rights to manage certain roles of their project.
+ZITADEL Console shows granted projects in a dedicated navigation menu, to clearly separate from your organization’s projects.
 
 ![Granted Projects Overview](/img/console_granted_projects_overview.png)
 
-Please note that you can also grant selected roles of a project to an individual user, instead of an organization. We will discuss this in more detail in a later section.
+Please note that you can also grant selected roles of a project to an individual user, instead of an organization.
+We will discuss this in more detail in a later section.

--- a/docs/docs/concepts/structure/_granted_project_description.mdx
+++ b/docs/docs/concepts/structure/_granted_project_description.mdx
@@ -7,17 +7,18 @@ An example could be a service provider that offers a SaaS solution that has diff
 As soon as a new client purchases the service, the provider could grant the roles `sales` and `accounting` to that organization,
 allowing them to self-manage how they want to allocate roles to their users.
 
-The process of assigning certain roles by default or according to rules can be further automated by utilizing Service Users in the service provider’s business process.
+The process of assigning certain roles by default or according to rules can be further automated by using Service Users in the service provider’s business process.
 
-Obviously, your organization can grant projects and receive projects.
-When you are granting, then the receiving organization will be displayed in the section GRANTED ORGANIZATIONS of your project.
+Your organization can grant and receive projects.
+After you grant, the receiving organization is displayed in the section GRANTED ORGANIZATIONS of your project.
 
 ![Project granted to organization](/img/console_projects_granted.png)
 
 A granted project, on the other hand, belongs to a third party, granting you some rights to manage certain roles of their project.
-ZITADEL Console shows granted projects in a dedicated navigation menu, to clearly separate from your organization’s projects.
+To clearly separate granted projects from your organization’s projects,
+ZITADEL Console shows granted projects in a dedicated navigation menu.
 
 ![Granted Projects Overview](/img/console_granted_projects_overview.png)
 
-Please note that you can also grant selected roles of a project to an individual user, instead of an organization.
-We will discuss this in more detail in a later section.
+Note that you can also grant selected roles of a project to an individual user, instead of an organization.
+We discuss this in more detail in a later section.

--- a/docs/docs/concepts/structure/_org_description.mdx
+++ b/docs/docs/concepts/structure/_org_description.mdx
@@ -1,4 +1,4 @@
-ZITADEL is organized around the idea that:
+ZITADEL takes the following approach to organizations:
 
 * Multiple organizations share the same system. In this case multiple organizations share the same service, zitadel.ch.
 * Organizations can grant each other rights to self-manage certain aspects of the IAM (eg, roles for access management).
@@ -6,12 +6,15 @@ ZITADEL is organized around the idea that:
 
 ![Overview ZITADEL Organizations](/img/concepts/objects/organization.png)
 
-Organizations in ZITADEL are therefore comparable to tenants of a system or organizational units of a directory based system.
+Organizations in ZITADEL are therefore comparable to tenants of a system, or to organizational units of a directory-based system.
 
-You can use projects within your organization to manage the security context of closely related components, such as roles, grants and authorizations for multiple clients. You can set up multiple projects within your organization.
+Within your organization, you can use projects to manage the security context of closely related components, such as roles, grants and authorizations for multiple clients. You can set up multiple projects within your organization.
 
 ZITADEL allows you to give other organizations permission to manage certain aspects of a project within your organization. This means you could set up a project with roles that should exist within your service/software, but allow another organization to allocate the roles to users within their own organization. As a service provider, you will find this feature useful, as it allows you to establish a self-service culture for your business customers.
 
 ![Organization Grant](/img/concepts/objects/organization_grants.png)
 
-Each organization has its own pool of usernames, which includes human and service users, for its domain (`{username}@{domainname}.{zitadeldomain}`). A username is unique within your organization. You can configure ZITADEL to use your own domain, and simplify user experience (`{loginname}@{yourdomain.tld}`).
+Each organization has its own pool of usernames for its domain (`{username}@{domainname}.{zitadeldomain}`).
+This naming structure applies to both human and service users.
+A username is unique within your organization
+You can configure ZITADEL to use your own domain, and simplifing the login experience for your users (`{loginname}@{yourdomain.tld}`).

--- a/docs/docs/concepts/structure/_org_description.mdx
+++ b/docs/docs/concepts/structure/_org_description.mdx
@@ -1,8 +1,8 @@
 ZITADEL is organized around the idea that:
 
-* Multiple organizations share the same system. In this case multiple organizations share the same service, zitadel.ch
-* organizations can grant each other rights to self-manage certain aspects of the IAM (eg, roles for access management)
-* organizations are vessels for users and projects
+* Multiple organizations share the same system. In this case multiple organizations share the same service, zitadel.ch.
+* Organizations can grant each other rights to self-manage certain aspects of the IAM (eg, roles for access management).
+* Organizations are vessels for users and projects.
 
 ![Overview ZITADEL Organizations](/img/concepts/objects/organization.png)
 
@@ -10,7 +10,7 @@ Organizations in ZITADEL are therefore comparable to tenants of a system or orga
 
 You can use projects within your organization to manage the security context of closely related components, such as roles, grants and authorizations for multiple clients. You can set up multiple projects within your organization.
 
-ZITADEL allows you to give other organizations permission to manage certain aspects of a project within your organization on their own. This means you could set up a project with roles that should exist within your service/software, but allow another organization to allocate the roles to users within their own organization. As a service provider, you will find this feature useful, as it allows you to establish a self-service culture for your business customers.
+ZITADEL allows you to give other organizations permission to manage certain aspects of a project within your organization. This means you could set up a project with roles that should exist within your service/software, but allow another organization to allocate the roles to users within their own organization. As a service provider, you will find this feature useful, as it allows you to establish a self-service culture for your business customers.
 
 ![Organization Grant](/img/concepts/objects/organization_grants.png)
 

--- a/docs/docs/concepts/structure/_org_description.mdx
+++ b/docs/docs/concepts/structure/_org_description.mdx
@@ -17,4 +17,5 @@ ZITADEL allows you to give other organizations permission to manage certain aspe
 Each organization has its own pool of usernames for its domain (`{username}@{domainname}.{zitadeldomain}`).
 This naming structure applies to both human and service users.
 A username is unique within your organization
-You can configure ZITADEL to use your own domain, and simplifing the login experience for your users (`{loginname}@{yourdomain.tld}`).
+You can configure ZITADEL to use your own domain (`{loginname}@{yourdomain.tld}`).
+This simplifies the login experience for your users.

--- a/docs/docs/concepts/structure/_project_description.mdx
+++ b/docs/docs/concepts/structure/_project_description.mdx
@@ -1,4 +1,4 @@
-Projects are a vessel for all components that closely related to one another.
+Projects are a vessel for all organization components that closely relate to one another.
 Multiple projects can exist within an organization.
 
 ![Organization grant](/img/concepts/objects/organization_grants.png)

--- a/docs/docs/concepts/structure/_project_description.mdx
+++ b/docs/docs/concepts/structure/_project_description.mdx
@@ -7,7 +7,7 @@ All applications within a project share the same roles, grants, and authorizatio
 
 * **Applications** is your software that initiates the authorization flow. This could be a web app and a mobile app that share the same roles.
 * **Roles** let you manage user-access rights for a project.
-* **Authorizations** define which users have which roles. Authorizations are also called __user grants_.
+* **Authorizations** define which users have which roles. Authorizations are also called _user grants_.
 * **Granted Organizations** can manage selected roles for your project on their own.
 
 ![Organization grant](/img/console_projects_overview.png)

--- a/docs/docs/concepts/structure/_project_description.mdx
+++ b/docs/docs/concepts/structure/_project_description.mdx
@@ -5,7 +5,7 @@ The idea of projects is to have a vessel for all components who are closely rela
 All applications within a project share the same roles, grants, and authorizations:
 
 * **Applications** is your software that initiates the authorization flow. This could be a web app and a mobile app that share the same roles.
-* **Roles** are a means of managing user access rights for a project.
+* **Roles** are means of managing user-access rights for a project.
 * **Authorizations** define which users have which roles. Authorizations are also called “user grants”.
 * **Granted Organizations** can manage selected roles for your project on their own.
 

--- a/docs/docs/concepts/structure/_project_description.mdx
+++ b/docs/docs/concepts/structure/_project_description.mdx
@@ -1,12 +1,13 @@
-The idea of projects is to have a vessel for all components who are closely related to each other. Multiple projects can exist within an organization.
+Projects are a vessel for all components that closely related to one another.
+Multiple projects can exist within an organization.
 
 ![Organization grant](/img/concepts/objects/organization_grants.png)
 
 All applications within a project share the same roles, grants, and authorizations:
 
 * **Applications** is your software that initiates the authorization flow. This could be a web app and a mobile app that share the same roles.
-* **Roles** are means of managing user-access rights for a project.
-* **Authorizations** define which users have which roles. Authorizations are also called “user grants”.
+* **Roles** let you manage user-access rights for a project.
+* **Authorizations** define which users have which roles. Authorizations are also called __user grants_.
 * **Granted Organizations** can manage selected roles for your project on their own.
 
 ![Organization grant](/img/console_projects_overview.png)

--- a/docs/docs/guides/api/access-zitadel-apis.md
+++ b/docs/docs/guides/api/access-zitadel-apis.md
@@ -13,7 +13,7 @@ title: Access ZITADEL APIs
             In this module you will:
             <ul>
                 <li>Grant a Service User for ZITADEL</li>
-                <li>Authorize a Service User with JWT signed with your private key</li>
+                <li>Authorize a Service User with a JWT that is signed with your private key</li>
             </ul>
         </td>
     </tr>
@@ -30,40 +30,41 @@ title: Access ZITADEL APIs
 
 ## ZITADEL Managers
 
-ZITADEL Managers are Users who have permission to manage ZITADEL itself. There are some different levels for managers. 
+ZITADEL Managers are Users who have permission to manage ZITADEL itself.
+There are some different levels for managers:
 
-- **IAM Managers**: This is the highest level. Users with IAM Manager roles are able to manage the whole IAM. 
-- **Org Managers**: Managers in the Organization Level are able to manage everything within the granted Organization.
-- **Project Mangers**: In this level the user is able to manage a project.
-- **Project Grant Manager**: The project grant manager is for projects, which are granted of another organization.
+- **IAM Managers**: This is the highest level. Users with IAM Manager roles can manage the whole IAM. 
+- **Org Managers**: Managers in the Organization Level can manage everything within the granted Organization.
+- **Project Mangers**: These user can manage a project.
+- **Project Grant Manager**: The project grant manager is for projects, which are granted by another organization.
 
-On each level we have some different Roles. Here you can find more about the different roles: [ZITADEL Manager Roles](../../concepts/structure/managers.md)
+Each level has different Roles. [Read more about ZITADEL Manager Roles](../../concepts/structure/managers.md).
 
 
 ## Exercise: Add ORG_OWNER to Service User
 
-Make sure you have a Service User with a Key. (For more detailed informations about creating a service user go to [Service User](../authentication/serviceusers))
+Make sure you have a Service User with a Key. (For more detailed information about creating a service user, see [Service User](../authentication/serviceusers)).
 
-1. Navigate to Organization Detail
-2. Click the **+** button in the right part of console, in the managers part of details
-3. Search the user and select it
-4. Choose the role ORG_OWNER
+1. Navigate to Organization Detail.
+2. On the right side of the console, in the manager's details, select the **+** button.
+3. Search for the user and select it.
+4. Choose the role `ORG_OWNER`.
 
 ![Add Org Manager](/img/console_org_manager_add.gif)
 
 ## Authenticating a service user
 
-In ZITADEL we use the `private_jwt` (**“JWT bearer token with private key”**, [RFC7523](https://tools.ietf.org/html/rfc7523)) authorization grant for this non-interactive authentication.
-This is already described in the [Service User](../authentication/serviceusers), so make sure you follow this guide.
+In ZITADEL, we use the `private_jwt` (**“JWT bearer token with private key”**, [RFC7523](https://tools.ietf.org/html/rfc7523)) authorization grant for this non-interactive authentication.
+For details, refer to the topic, [Service User](../authentication/serviceusers).
 
 ### Request an OAuth token, with audience for ZITADEL
 
-With the encoded JWT from the prior step, you will need to craft a POST request to ZITADEL's token endpoint:
+With the encoded JWT from the prior step, craft a POST request to ZITADEL's token endpoint:
 
-To access the ZITADEL APIs you need the ZITADEL Project ID in the audience of your token.
-This is possible by sending a custom scope for the audience. More about [Custom Scopes](../../apis/openidoauth/scopes)
+To access the ZITADEL APIs, you need the ZITADEL Project ID in the audience of your token.
+This is possible by sending a custom scope for the audience. [Read more about Custom Scopes](../../apis/openidoauth/scopes).
 
-Use the scope `urn:zitadel:iam:org:project:id:{projectid}:aud` to include the project id in your audience
+Use the scope `urn:zitadel:iam:org:project:id:{projectid}:aud` to include the project id in your audience:
 
 > The scope for zitadel.ch is: `urn:zitadel:iam:org:project:id:69234237810729019:aud`
 
@@ -76,9 +77,9 @@ curl --request POST \
   --data assertion=eyJ0eXAiOiJKV1QiL...
 ```
 
-* `grant_type` must be set to `urn:ietf:params:oauth:grant-type:jwt-bearer`
-* `scope` should contain any [Scopes](../../apis/openidoauth/scopes) you want to include, but must include `openid`. For this example, please include `profile` and `email`
-* `assertion` is the encoded value of the JWT that was signed with your private key from the prior step
+* `grant_type` must be `urn:ietf:params:oauth:grant-type:jwt-bearer`.
+* `scope` should contain any [Scopes](../../apis/openidoauth/scopes) you want to include, but must include `openid`. For this example, please include `profile` and `email`.
+* `assertion` is the encoded value of the JWT that was signed with your private key from the prior step.
 
 You should receive a successful response with `access_token`,  `token_type` and time to expiry in seconds as `expires_in`.
 
@@ -93,14 +94,14 @@ Content-Type: application/json
 }
 ```
 
-With this token you are allowed to access the [ZITADEL APIs](../../apis/introduction) .
+With this token, you can access the [ZITADEL APIs](../../apis/introduction) .
+
 ## Knowledge Check
 
-
-* Managers are used for all users to get authorizations for all projects?
+* Managers are used for all users to get authorizations for all projects.
     - [ ] yes
     - [ ] no
-* You need the ZITADEL Project Id in your audience and can access this with a custom scope?
+* You need the ZITADEL Project Id in your audience and can access this with a custom scope.
     - [ ] yes
     - [ ] no
 
@@ -113,7 +114,7 @@ With this token you are allowed to access the [ZITADEL APIs](../../apis/introduc
 
 * Managers are used for all users to get authorizations for all projects?
     - [ ] yes
-    - [x] no (Managers are only used to grant users for ZITADEL)
+    - [x] no (Managers are used only to grant users for ZITADEL)
 * You need the ZITADEL Project Id in your audience and can access this with a custom scope?
     - [x] yes
     - [ ] no
@@ -123,8 +124,8 @@ With this token you are allowed to access the [ZITADEL APIs](../../apis/introduc
 ## Summary
 
 * Grant a user for ZITADEL
-* Because there is no interactive logon, you need to use a JWT signed with your private key to authorize the user
-* With a custom scope (`urn:zitadel:iam:org:project:id:{projectid}:aud`) you can access ZITADEL APIs
+* Because there is no interactive logon, you need to use a JWT that is signed with your private key to authorize the user.
+* With a custom scope (`urn:zitadel:iam:org:project:id:{projectid}:aud`), you can access ZITADEL APIs.
 
 
 Where to go from here:

--- a/docs/docs/guides/api/access-zitadel-apis.md
+++ b/docs/docs/guides/api/access-zitadel-apis.md
@@ -115,7 +115,7 @@ With this token, you can access the [ZITADEL APIs](../../apis/introduction) .
 * Managers are used for all users to get authorizations for all projects.
     - [ ] yes
     - [x] no (Managers are used only to grant users for ZITADEL)
-* You need the ZITADEL Project Id in your audience and can access this with a custom scope?
+* You need the ZITADEL Project Id in your audience and can access this with a custom scope.
     - [x] yes
     - [ ] no
 

--- a/docs/docs/guides/api/access-zitadel-apis.md
+++ b/docs/docs/guides/api/access-zitadel-apis.md
@@ -112,7 +112,7 @@ With this token, you can access the [ZITADEL APIs](../../apis/introduction) .
     </summary>
 
 
-* Managers are used for all users to get authorizations for all projects?
+* Managers are used for all users to get authorizations for all projects.
     - [ ] yes
     - [x] no (Managers are used only to grant users for ZITADEL)
 * You need the ZITADEL Project Id in your audience and can access this with a custom scope?

--- a/docs/docs/guides/api/access-zitadel-apis.md
+++ b/docs/docs/guides/api/access-zitadel-apis.md
@@ -35,7 +35,7 @@ There are some different levels for managers:
 
 - **IAM Managers**: This is the highest level. Users with IAM Manager roles can manage the whole IAM. 
 - **Org Managers**: Managers in the Organization Level can manage everything within the granted Organization.
-- **Project Mangers**: These user can manage a project.
+- **Project Mangers**: These users can manage projects.
 - **Project Grant Manager**: The project grant manager is for projects, which are granted by another organization.
 
 Each level has different Roles. [Read more about ZITADEL Manager Roles](../../concepts/structure/managers.md).

--- a/docs/docs/guides/authentication/authmethods/basic.mdx
+++ b/docs/docs/guides/authentication/authmethods/basic.mdx
@@ -13,7 +13,7 @@ If you need to distinguish different environments, we recommend using multiple p
 To initialize the user authentication, create an authorization request to `/authorize`, using the HTTP GET method in the user agent (browser).
 The request needs at least the following parameters:
 
-- `client_id`: how the authorization server knows which application it is. Copy from Console.
+- `client_id`: how the authorization server knows which application it is. Copy from the console.
 - `redirect_uri`: where the authorization code is sent to after user authentication. Must be one of the registered URIs in the previous step.
 - `response_type`: whether you want to have a code (authorization code flow) or a token (implicit flow). Whenever possible, use `code`
 - `scope`: what scope you want to grant to the access_token / id_token, minimum is `openid`. If you're unsure what you need, you might start with `openid profile email`

--- a/docs/docs/guides/authentication/authmethods/basic.mdx
+++ b/docs/docs/guides/authentication/authmethods/basic.mdx
@@ -1,25 +1,29 @@
 #### redirect_uri
 
-After selecting the authentication method, you can register a redirect_uri and post_logout_redirect_uri.
-The redirect_uri will be called after user authentication for code exchange.
+After selecting the authentication method, you can register a `redirect_uri` and `post_logout_redirect_uri`.
+After the user authenticates, the `redirect_uri` is called for code exchange.
 
-You can even register multiple, but typically one will be enough. If you need to distinguish between different scenarios
-or environments we recommend using the `state` parameter for the former and multiple projects for the latter.
+Typically one `redirect_uri` is enough, but you can have multiple.
+If you need to distinguish between different scenarios,
+we recommend using the `state` parameter.
+If you need to distinguish different environments, we recommend using multiple projects.
 
 ## Auth Request
 
-To initialize the user authentication, you will have to create an authorization request using HTTP GET in the user agent (browser)
-on /authorize with at least the following parameters:
+To initialize the user authentication, create an authorization request using HTTP GET in the user agent (browser) to `/authorize`.
+The request needs at least the following parameters:
 
-- `client_id`: this tells the authorization server which application it is, copy from Console
-- `redirect_uri`: where the authorization code is sent to after the user authentication, must be one of the registered in the previous step
-- `response_type`: if you want to have a code (authorization code flow) or directly a token (implicit flow), so when ever possible use `code`
-- `scope`: what scope you want to grant to the access_token / id_token, minimum is `openid`, if you're unsure what you need you might start with `openid profile email`
+- `client_id`: how the authorization server knows which application it is. Copy from Console.
+- `redirect_uri`: where the authorization code is sent to after the user authentication. Must be one of the registered URIs in the previous step.
+- `response_type`: whether you want to have a code (authorization code flow) or a token (implicit flow). Whenever possible, use `code`
+- `scope`: what scope you want to grant to the access_token / id_token, minimum is `openid`. If you're unsure what you need, you might start with `openid profile email`
 
-We recommend always using two additional parameters `state` and `nonce`. The former enables you to transfer a state through
-the authentication process. The latter is used to bind the client session with the id_token and to mitigate replay attacks.
+We recommend always using two additional parameters: `state` and `nonce`.
+`State` lets you to transfer a state through the authentication process.
+`Nonce` is used to bind the client session with the `id_token`, and to mitigate replay attacks.
 
-You don't need any additional parameter for this request. We're identifying the app by the `client_id` parameter.
+You don't need any additional parameters for this request.
+We identify the app by the `client_id` parameter.
 
 So your request might look like this (linebreaks and whitespace for display reasons):
 
@@ -34,38 +38,38 @@ curl --request GET \
 
 ### Additional parameters and customization
 
-There are additional parameters and values you can provide to satisfy your use case and to customize the user's authentication flow.
+To customize the user's authentication flow, there are additional parameters and values you can provide to satisfy your use case.
 Please check the [authorization_endpoint reference](/docs/apis/openidoauth/endpoints#authorization_endpoint) in the OAuth / OIDC documentation.
 
 ## Callback
 
-Regardless of a successful or error response from the authorization_endpoint, the authorization server will call your
-callback endpoint you provided by the `redirect_uri`.
+No matter whether the `authorization_endpoint` response returns a success message or an error,
+the authorization server will call the callback endpoint that you provided in the `redirect_uri`.
 
 :::note
-If the redirect_uri is not provided, was not registered or anything other prevents the auth server form returning the response to the client,
-the error will be display directly to the user on the auth server.
+If no `redirect_uri` is registered, or if anything else prevents the auth server from returning the response to the client,
+the error is displayed directly on the auth server.
 :::
 
-Upon successful authentication you'll be given a `code` and if provided the unmodified `state` parameter.
+Upon successful authentication, you'll be given a `code` and, if provided, the unmodified `state` parameter.
 You will need this `code` in the token request.
 
-If a parameter was missing, malformed or any other error occurred, your answer will contain an `error` stating the error type,
-possibly an `error_description` providing some information about the error and its reason and the `state` parameter.
+If a parameter is missing, malformed, or any other error occurred, your answer will contain an `error`.
+This error states the error type, and possibly gives an `error_description`, which provides some information about the error, its reason, and the `state` parameter.
 Check the [error response section](/docs/apis/openidoauth/endpoints#error-response) in the authorization_endpoint reference.
 
 ## Token request
 
-Next you will have to exchange the given `code` for the tokens. For this HTTP POST request (form-urlencoded) you will need to provide the following:
+Next you need to exchange the given `code` for the tokens. For this HTTP POST request (form-urlencoded), you need to provide the following:
 
-- code: the code that was issued from the authorization request
-- grant_type: must be `authorization_code`
-- redirect_uri: callback uri where the code was sent to. Must match exactly the redirect_uri of the authorization request
+- `code`: the code that was issued from the authorization request
+- `grant_type`: must be `authorization_code`
+- `redirect_uri`: callback URI where the code was sent to. Must match exactly the `redirect_uri` of the authorization request
 
-Depending on your authentication method you'll need additional headers and parameters:
+Depending on your authentication method, you'll need additional headers and parameters:
 
 Send your `client_id` and `client_secret` as Basic Auth Header. Note that OAuth2 requires client_id and client_secret to be form url encoded.
-So check [Client Secret Basic Auth Method](/docs/apis/openidoauth/authn-methods#client-secret-basic) on how to build it correctly.
+So check [Client Secret Basic Auth Method](/docs/apis/openidoauth/authn-methods#client-secret-basic) for instructions about how to build it correctly.
 
 ```curl
 curl --request POST \

--- a/docs/docs/guides/authentication/authmethods/basic.mdx
+++ b/docs/docs/guides/authentication/authmethods/basic.mdx
@@ -10,11 +10,11 @@ If you need to distinguish different environments, we recommend using multiple p
 
 ## Auth Request
 
-To initialize the user authentication, create an authorization request using HTTP GET in the user agent (browser) to `/authorize`.
+To initialize the user authentication, create an authorization request to `/authorize`, using the HTTP GET method in the user agent (browser).
 The request needs at least the following parameters:
 
 - `client_id`: how the authorization server knows which application it is. Copy from Console.
-- `redirect_uri`: where the authorization code is sent to after the user authentication. Must be one of the registered URIs in the previous step.
+- `redirect_uri`: where the authorization code is sent to after user authentication. Must be one of the registered URIs in the previous step.
 - `response_type`: whether you want to have a code (authorization code flow) or a token (implicit flow). Whenever possible, use `code`
 - `scope`: what scope you want to grant to the access_token / id_token, minimum is `openid`. If you're unsure what you need, you might start with `openid profile email`
 

--- a/docs/docs/guides/authentication/authmethods/basic.mdx
+++ b/docs/docs/guides/authentication/authmethods/basic.mdx
@@ -68,7 +68,8 @@ Next you need to exchange the given `code` for the tokens. For this HTTP POST re
 
 Depending on your authentication method, you'll need additional headers and parameters:
 
-Send your `client_id` and `client_secret` as Basic Auth Header. Note that OAuth2 requires client_id and client_secret to be form url encoded.
+Send your `client_id` and `client_secret` as Basic Auth Header.
+Note that OAuth2 requires `client_id` and `client_secret` to be form url encoded.
 So check [Client Secret Basic Auth Method](/docs/apis/openidoauth/authn-methods#client-secret-basic) for instructions about how to build it correctly.
 
 ```curl

--- a/docs/docs/guides/authentication/authmethods/implicit.mdx
+++ b/docs/docs/guides/authentication/authmethods/implicit.mdx
@@ -40,7 +40,8 @@ Please check the [authorization_endpoint reference](/docs/apis/openidoauth/endpo
 
 ## Callback
 
-Regardless of a successful or error response from the authorization_endpoint, the authorization server will call your callback endpoint you provided by the `redirect_uri`.
+No matter wheter the `authorization_endpoint` response returns a success message or an error,
+the authorization server will call your callback endpoint you provided by the `redirect_uri`.
 
 :::note
 If no `redirect_uri` is registered, or if anything else prevents the auth server from returning the response to the client,

--- a/docs/docs/guides/authentication/authmethods/implicit.mdx
+++ b/docs/docs/guides/authentication/authmethods/implicit.mdx
@@ -1,37 +1,41 @@
 :::caution Security Notice
 In contrast to the Code Flow, where you'll receive a code for token exchange, with the implicit flow you'll receive
 the tokens directly from the authorization endpoint. This is unsecure and might lead to token leakage and replay attacks.
-It will further be removed in OAuth 2.1 for the exact same reason.
+For this exact reason, OAuth 2.1 will remove implicit flow.
 
 We therefore discourage the use of Implicit Flow and do not cover the flow in this guide.
 :::
 
-If you still need to rely on the implicit flow, simply keep in mind that the response on the authorization_endpoint is
-the same you would be given on the token_endpoint and check the [OAuth / OIDC endpoint documentation](/docs/apis/openidoauth/endpoints) for more information.
+If you still need to rely on implicit flow, note that the `authorization_endpoint` gives the same response that the `token_endpoint`does.
+Check the [OAuth / OIDC endpoint documentation](/docs/apis/openidoauth/endpoints) for more information.
 
 #### redirect_uri
 
-After selecting the authentication method, you can register a redirect_uri and post_logout_redirect_uri.
-The redirect_uri will be called after user authentication for code exchange.
+After selecting the authentication method, you can register a `redirect_uri` and `post_logout_redirect_uri`.
+After the user authenticates, the `redirect_uri` is called for code exchange.
 
-You can even register multiple, but typically one will be enough. If you need to distinguish between different scenarios
-or environments we recommend using the `state` parameter for the former and multiple projects for the latter.
+Typically one `redirect_uri` is enough, but you can have multiple.
+If you need to distinguish between different scenarios,
+we recommend using the `state` parameter.
+If you need to distinguish different environments, we recommend using multiple projects.
 
 ## Auth Request
 
-To initialize the user authentication, you will have to create an authorization request using HTTP GET in the user agent (browser)
-on /authorize with at least the following parameters:
+To initialize the user authentication, create an authorization request to `/authorize`, using the HTTP GET method in the user agent (browser).
+The request needs at least the following parameters:
 
-- `client_id`: this tells the authorization server which application it is, copy from Console
-- `redirect_uri`: where the authorization code is sent to after the user authentication, must be one of the registered in the previous step
-- `response_type`: if you want to have a code (authorization code flow) or directly a token (implicit flow), so when ever possible use `code`
-- `scope`: what scope you want to grant to the access_token / id_token, minimum is `openid`, if you're unsure what you need you might start with `openid profile email`
+- `client_id`: how the authorization server knows which application it is. Copy from Console.
+- `redirect_uri`: where the authorization code is sent to after user authentication. Must be one of the registered URIs in the previous step.
+- `response_type`: whether you want to have a code (authorization code flow) or a token (implicit flow). Whenever possible, use `code`
+- `scope`: what scope you want to grant to the access_token / id_token, minimum is `openid`. If you're unsure what you need, you might start with `openid profile email`
 
-When using the Implicit Flow you will also have to provide a `nonce` parameter to bind the client session to the id_token and to mitigate replay attacks. Furthermore, we recommend using a `state` parameter, which enables you to transfer a state through the authentication process.
+When using the Implicit Flow, provide a `nonce` parameter to bind the client session to the `id_token` and to mitigate replay attacks.
+Furthermore, we recommend using a `state` parameter, which lets
+you to transfer a state through the authentication process.
 
 ### Additional parameters and customization
 
-There are additional parameters and values you can provide to satisfy your use case and to customize the user's authentication flow.
+To customize the user's authentication flow, there are additional parameters and values you can provide to satisfy your use case.
 Please check the [authorization_endpoint reference](/docs/apis/openidoauth/endpoints#authorization_endpoint) in the OAuth / OIDC documentation.
 
 ## Callback
@@ -39,11 +43,12 @@ Please check the [authorization_endpoint reference](/docs/apis/openidoauth/endpo
 Regardless of a successful or error response from the authorization_endpoint, the authorization server will call your callback endpoint you provided by the `redirect_uri`.
 
 :::note
-If the redirect_uri is not provided, was not registered or anything other prevents the auth server form returning the response to the client, the error will be display directly to the user on the auth server.
+If no `redirect_uri` is registered, or if anything else prevents the auth server from returning the response to the client,
+the error is displayed directly on the auth server.
 :::
 
-Upon successful authentication you'll be given the `access_token`, `id_token`, `expires_in` and if provided the unmodified `state` parameter, as you would be given from the token_endpoint when using Authorization Code Flow.
+Upon successful authentication, you'll be given the `access_token`, `id_token`, `expires_in` and, if provided, the unmodified `state` parameter, as you would be given from the `token_endpoint` when using Authorization Code Flow.
 
-If a parameter was missing, malformed or any other error occurred, your answer will contain an `error` stating the error type,
-possibly an `error_description` providing some information about the error and its reason and the `state` parameter.
+If a parameter is missing, malformed, or any other error occurred, your answer will contain an `error`.
+This error states the error type, and possibly gives an `error_description`, which provides some information about the error, its reason, and the `state` parameter.
 Check the [error response section](/docs/apis/openidoauth/endpoints#error-response) in the authorization_endpoint reference.

--- a/docs/docs/guides/authentication/authmethods/implicit.mdx
+++ b/docs/docs/guides/authentication/authmethods/implicit.mdx
@@ -6,7 +6,7 @@ For this exact reason, OAuth 2.1 will remove implicit flow.
 We therefore discourage the use of Implicit Flow and do not cover the flow in this guide.
 :::
 
-If you still need to rely on implicit flow, note that the `authorization_endpoint` gives the same response that the `token_endpoint`does.
+If you still need to rely on implicit flow, note that the `authorization_endpoint` gives the same response that the `token_endpoint` does.
 Check the [OAuth / OIDC endpoint documentation](/docs/apis/openidoauth/endpoints) for more information.
 
 #### redirect_uri

--- a/docs/docs/guides/authentication/authmethods/implicit.mdx
+++ b/docs/docs/guides/authentication/authmethods/implicit.mdx
@@ -24,7 +24,7 @@ If you need to distinguish different environments, we recommend using multiple p
 To initialize the user authentication, create an authorization request to `/authorize`, using the HTTP GET method in the user agent (browser).
 The request needs at least the following parameters:
 
-- `client_id`: how the authorization server knows which application it is. Copy from Console.
+- `client_id`: how the authorization server knows which application it is. Copy from the console.
 - `redirect_uri`: where the authorization code is sent to after user authentication. Must be one of the registered URIs in the previous step.
 - `response_type`: whether you want to have a code (authorization code flow) or a token (implicit flow). Whenever possible, use `code`
 - `scope`: what scope you want to grant to the access_token / id_token, minimum is `openid`. If you're unsure what you need, you might start with `openid profile email`

--- a/docs/docs/guides/authentication/authmethods/jwtpk.mdx
+++ b/docs/docs/guides/authentication/authmethods/jwtpk.mdx
@@ -13,7 +13,7 @@ If you need to distinguish different environments, we recommend using multiple p
 To initialize the user authentication, create an authorization request to `/authorize`, using the HTTP GET method in the user agent (browser).
 The request needs at least the following parameters:
 
-- `client_id`: how the authorization server knows which application it is. Copy from Console.
+- `client_id`: how the authorization server knows which application it is. Copy from the console.
 - `redirect_uri`: where the authorization code is sent to after user authentication. Must be one of the registered URIs in the previous step.
 - `response_type`: whether you want to have a code (authorization code flow) or a token (implicit flow). Whenever possible, use `code`
 - `scope`: what scope you want to grant to the access_token / id_token, minimum is `openid`. If you're unsure what you need, you might start with `openid profile email`

--- a/docs/docs/guides/authentication/authmethods/jwtpk.mdx
+++ b/docs/docs/guides/authentication/authmethods/jwtpk.mdx
@@ -1,25 +1,29 @@
 #### redirect_uri
 
-After selecting the authentication method, you can register a redirect_uri and post_logout_redirect_uri.
-The redirect_uri will be called after user authentication for code exchange.
+After selecting the authentication method, you can register a `redirect_uri` and `post_logout_redirect_uri`.
+After the user authenticates, the `redirect_uri` is called for code exchange.
 
-You can even register multiple, but typically one will be enough. If you need to distinguish between different scenarios
-or environments we recommend using the `state` parameter for the former and multiple projects for the latter.
+Typically one `redirect_uri` is enough, but you can have multiple.
+If you need to distinguish between different scenarios,
+we recommend using the `state` parameter.
+If you need to distinguish different environments, we recommend using multiple projects.
 
 ## Auth Request
 
-To initialize the user authentication, you will have to create an authorization request using HTTP GET in the user agent (browser)
-on /authorize with at least the following parameters:
+To initialize the user authentication, create an authorization request to `/authorize`, using the HTTP GET method in the user agent (browser).
+The request needs at least the following parameters:
 
-- `client_id`: this tells the authorization server which application it is, copy from Console
-- `redirect_uri`: where the authorization code is sent to after the user authentication, must be one of the registered in the previous step
-- `response_type`: if you want to have a code (authorization code flow) or directly a token (implicit flow), so when ever possible use `code`
-- `scope`: what scope you want to grant to the access_token / id_token, minimum is `openid`, if you're unsure what you need you might start with `openid profile email`
+- `client_id`: how the authorization server knows which application it is. Copy from Console.
+- `redirect_uri`: where the authorization code is sent to after user authentication. Must be one of the registered URIs in the previous step.
+- `response_type`: whether you want to have a code (authorization code flow) or a token (implicit flow). Whenever possible, use `code`
+- `scope`: what scope you want to grant to the access_token / id_token, minimum is `openid`. If you're unsure what you need, you might start with `openid profile email`
 
-We recommend always using two additional parameters `state` and `nonce`. The former enables you to transfer a state through
-the authentication process. The latter is used to bind the client session with the id_token and to mitigate replay attacks.
+We recommend always using two additional parameters: `state` and `nonce`.
+`State` lets you to transfer a state through the authentication process.
+`Nonce` is used to bind the client session with the `id_token`, and to mitigate replay attacks.
 
-You don't need any additional parameter for this request. We're identifying the app by the `client_id` parameter.
+You don't need any additional parameters for this request.
+We identify the app by the `client_id` parameter.
 
 So your request might look like this (linebreaks and whitespace for display reasons):
 

--- a/docs/docs/guides/authentication/authmethods/jwtpk.mdx
+++ b/docs/docs/guides/authentication/authmethods/jwtpk.mdx
@@ -34,37 +34,39 @@ curl --request GET \
 
 ### Additional parameters and customization
 
-There are additional parameters and values you can provide to satisfy your use case and to customize the user's authentication flow.
+To customize the user's authentication flow, there are additional parameters and values you can provide to satisfy your use case.
 Please check the [authorization_endpoint reference](/docs/apis/openidoauth/endpoints#authorization_endpoint) in the OAuth / OIDC documentation.
 
 ## Callback
 
-Regardless of a successful or error response from the authorization_endpoint, the authorization server will call your
-callback endpoint you provided by the `redirect_uri`.
+No matter whether the `authorization_endpoint` response returns a success message or an error,
+the authorization server will call the callback endpoint that you provided in the `redirect_uri`.
 
 :::note
-If the redirect_uri is not provided, was not registered or anything other prevents the auth server form returning the response to the client,
-the error will be display directly to the user on the auth server.
+If no `redirect_uri` is registered, or if anything else prevents the auth server from returning the response to the client,
+the error is displayed directly on the auth server.
 :::
 
-Upon successful authentication you'll be given a `code` and if provided the unmodified `state` parameter.
+Upon successful authentication, you'll be given a `code` and, if provided, the unmodified `state` parameter.
 You will need this `code` in the token request.
 
-If a parameter was missing, malformed or any other error occurred, your answer will contain an `error` stating the error type,
-possibly an `error_description` providing some information about the error and its reason and the `state` parameter.
+If a parameter is missing, malformed, or any other error occurred, your answer will contain an `error`.
+This error states the error type, and possibly gives an `error_description`, which provides some information about the error, its reason, and the `state` parameter.
 Check the [error response section](/docs/apis/openidoauth/endpoints#error-response) in the authorization_endpoint reference.
 
 ## Token request
 
-Next you will have to exchange the given `code` for the tokens. For this HTTP POST request (form-urlencoded) you will need to provide the following:
+Next you need to exchange the given `code` for the tokens.
+For this HTTP POST request (form-urlencoded), you need to provide the following:
 
-- code: the code that was issued from the authorization request
-- grant_type: must be `authorization_code`
-- redirect_uri: callback uri where the code was sent to. Must match exactly the redirect_uri of the authorization request
+- `code`: the code that was issued from the authorization request
+- `grant_type`: must be `authorization_code`
+- `redirect_uri`: callback URI where the code was sent to. Must match exactly the `redirect_uri` of the authorization request
 
 Depending on your authentication method you'll need additional headers and parameters:
 
-Send a JWT in the `client_assertion` and set the `client_assertion_type` to `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`
+Send a JWT in the `client_assertion`.
+Set the `client_assertion_type` to `urn:ietf:params:oauth:client-assertion-type:jwt-bearer`
 for us to validate the signature against the registered public key:
 
 ```curl

--- a/docs/docs/guides/authentication/authmethods/pkce.mdx
+++ b/docs/docs/guides/authentication/authmethods/pkce.mdx
@@ -1,35 +1,42 @@
 #### redirect_uri
 
-After selecting the authentication method, you can register a redirect_uri and post_logout_redirect_uri.
-The redirect_uri will be called after user authentication for code exchange.
+After selecting the authentication method, you can register a `redirect_uri` and `post_logout_redirect_uri`.
+After the user authenticates, the `redirect_uri` is called for code exchange.
 
-You can even register multiple, but typically one will be enough. If you need to distinguish between different scenarios
-or environments we recommend using the `state` parameter for the former and multiple projects for the latter.
+Typically one `redirect_uri` is enough, but you can have multiple.
+If you need to distinguish between different scenarios,
+we recommend using the `state` parameter.
+If you need to distinguish different environments, we recommend using multiple projects.
 
 ## Auth Request
 
-To initialize the user authentication, you will have to create an authorization request using HTTP GET in the user agent (browser)
-on /authorize with at least the following parameters:
+To initialize the user authentication, create an authorization request to `/authorize`, using the HTTP GET method in the user agent (browser).
+The request needs at least the following parameters:
 
-- `client_id`: this tells the authorization server which application it is, copy from Console
-- `redirect_uri`: where the authorization code is sent to after the user authentication, must be one of the registered in the previous step
-- `response_type`: if you want to have a code (authorization code flow) or directly a token (implicit flow), so when ever possible use `code`
-- `scope`: what scope you want to grant to the access_token / id_token, minimum is `openid`, if you're unsure what you need you might start with `openid profile email`
+- `client_id`: how the authorization server knows which application it is. Copy from Console.
+- `redirect_uri`: where the authorization code is sent to after user authentication. Must be one of the registered URIs in the previous step.
+- `response_type`: whether you want to have a code (authorization code flow) or a token (implicit flow). Whenever possible, use `code`
+- `scope`: what scope you want to grant to the access_token / id_token, minimum is `openid`. If you're unsure what you need, you might start with `openid profile email`
 
-We recommend always using two additional parameters `state` and `nonce`. The former enables you to transfer a state through
-the authentication process. The latter is used to bind the client session with the id_token and to mitigate replay attacks.
+We recommend always using two additional parameters: `state` and `nonce`.
+`State` lets you to transfer a state through the authentication process.
+`Nonce` is used to bind the client session with the `id_token`, and to mitigate replay attacks.
 
-PKCE stands for Proof Key for Code Exchange. So other than "normal" code exchange, the does not authenticate using
-client_id and client_secret but an additional code. You will have to generate a random string, hash it and send this hash
-on the authorization_endpoint. On the token_endpoint you will then send the plain string for the authorization to compute
-the hash as well and to verify it's correct. In order to do so you're required to send the following two parameters as well:
+
+PKCE stands for __Proof Key for Code Exchange_.
+So other than "normal" code exchange, it does not authenticate using
+`client_id` and `client_secret`, but through an additional code.
+You will have to generate a random string, hash it and send this hash
+to the `authorization_endpoint`.
+Then send the plain string to the `token_endpoint` for the authorization to compute the hash to verify it matches.
+In order to do so, you're required to send the following two parameters as well:
 
 - `code_challenge`: the base64url representation of the (sha256) hash of your random string
-- `code_challenge_method`: must always be `S256` standing for sha256, this is the only algorithm we support
+- `code_challenge_method`: must be `S256`. Standing for sha256, this is the only algorithm we support
 
-For example for `random-string` the code_challenge would be `9az09PjcfuENS7oDK7jUd2xAWRb-B3N7Sr3kDoWECOY`
+For example for `random-string`, the `code_challenge` would be `9az09PjcfuENS7oDK7jUd2xAWRb-B3N7Sr3kDoWECOY`
 
-The request would finally look like (linebreaks and whitespace for display reasons):
+The request would finally look like this (linebreaks and whitespace for display reasons):
 
 ```curl
 curl --request GET \
@@ -44,33 +51,34 @@ curl --request GET \
 
 ### Additional parameters and customization
 
-There are additional parameters and values you can provide to satisfy your use case and to customize the user's authentication flow.
+To customize the user's authentication flow, there are additional parameters and values you can provide to satisfy your use case.
 Please check the [authorization_endpoint reference](/docs/apis/openidoauth/endpoints#authorization_endpoint) in the OAuth / OIDC documentation.
 
 ## Callback
 
-Regardless of a successful or error response from the authorization_endpoint, the authorization server will call your
-callback endpoint you provided by the `redirect_uri`.
+No matter whether the `authorization_endpoint` response returns a success message or an error,
+the authorization server will call the callback endpoint that you provided in the `redirect_uri`.
 
 :::note
-If the redirect_uri is not provided, was not registered or anything other prevents the auth server form returning the response to the client,
-the error will be display directly to the user on the auth server.
+If no `redirect_uri` is registered, or if anything else prevents the auth server from returning the response to the client,
+the error is displayed directly on the auth server.
 :::
 
-Upon successful authentication you'll be given a `code` and if provided the unmodified `state` parameter.
+Upon successful authentication, you'll be given a `code` and, if provided, the unmodified `state` parameter.
 You will need this `code` in the token request.
 
-If a parameter was missing, malformed or any other error occurred, your answer will contain an `error` stating the error type,
-possibly an `error_description` providing some information about the error and its reason and the `state` parameter.
+If a parameter is missing, malformed, or any other error occurred, your answer will contain an `error`.
+This error states the error type, and possibly gives an `error_description`, which provides some information about the error, its reason, and the `state` parameter.
 Check the [error response section](/docs/apis/openidoauth/endpoints#error-response) in the authorization_endpoint reference.
 
 ## Token request
 
-Next you will have to exchange the given `code` for the tokens. For this HTTP POST request (form-urlencoded) you will need to provide the following:
+Next you need to exchange the given `code` for the tokens.
+For this HTTP POST request (form-urlencoded), you need to provide the following:
 
-- code: the code that was issued from the authorization request
-- grant_type: must be `authorization_code`
-- redirect_uri: callback uri where the code was sent to. Must match exactly the redirect_uri of the authorization request
+- `code`: the code that was issued from the authorization request
+- `grant_type`: must be `authorization_code`
+- `redirect_uri`: callback URI where the code was sent to. Must match exactly the `redirect_uri` of the authorization request
 
 Depending on your authentication method you'll need additional headers and parameters:
 

--- a/docs/docs/guides/authentication/authmethods/pkce.mdx
+++ b/docs/docs/guides/authentication/authmethods/pkce.mdx
@@ -26,7 +26,8 @@ We recommend always using two additional parameters: `state` and `nonce`.
 PKCE stands for __Proof Key for Code Exchange_.
 So other than "normal" code exchange, it does not authenticate using
 `client_id` and `client_secret`, but through an additional code.
-You will have to generate a random string, hash it and send this hash
+
+Generate a random string, hash it and send this hash
 to the `authorization_endpoint`.
 Then send the plain string to the `token_endpoint` for the authorization to compute the hash to verify it matches.
 In order to do so, you're required to send the following two parameters as well:

--- a/docs/docs/guides/authentication/authmethods/pkce.mdx
+++ b/docs/docs/guides/authentication/authmethods/pkce.mdx
@@ -13,7 +13,7 @@ If you need to distinguish different environments, we recommend using multiple p
 To initialize the user authentication, create an authorization request to `/authorize`, using the HTTP GET method in the user agent (browser).
 The request needs at least the following parameters:
 
-- `client_id`: how the authorization server knows which application it is. Copy from Console.
+- `client_id`: how the authorization server knows which application it is. copy from the console.
 - `redirect_uri`: where the authorization code is sent to after user authentication. Must be one of the registered URIs in the previous step.
 - `response_type`: whether you want to have a code (authorization code flow) or a token (implicit flow). Whenever possible, use `code`
 - `scope`: what scope you want to grant to the access_token / id_token, minimum is `openid`. If you're unsure what you need, you might start with `openid profile email`

--- a/docs/docs/guides/authentication/authmethods/pkcenative.mdx
+++ b/docs/docs/guides/authentication/authmethods/pkcenative.mdx
@@ -1,6 +1,6 @@
 #### redirect_uri
 
-Native clients might have to register more than one `redirect_uri`, as operating system have different requirements.
+Native clients might have to register more than one `redirect_uri`, as different operating systems can have different requirements.
 Typically, you register a `redirect_uri` starting with a custom protocol, e.g. `ch.zitadel.app://callback`.
 You're also allowed to use http://localhost, http://127.0.0.1 and http:[::1] without specifying a port: `http://locahost/callback`.
 

--- a/docs/docs/guides/authentication/authmethods/pkcenative.mdx
+++ b/docs/docs/guides/authentication/authmethods/pkcenative.mdx
@@ -1,51 +1,54 @@
 #### redirect_uri
 
-Native clients might have to register multiple redirect_uris as operating system have different requirements.
-Typically, you register a redirect_uri starting with a custom protocol, e.g. `ch.zitadel.app://callback`.
+Native clients might have to register multiple `redirect_uris`, as operating system have different requirements.
+Typically, you register a `redirect_uri` starting with a custom protocol, e.g. `ch.zitadel.app://callback`.
 You're also allowed to use http://localhost, http://127.0.0.1 and http:[::1] without specifying a port: `http://locahost/callback`.
 
 #### post creation actions
 
-After the application creation, you might want to set additional options like `refresh_token` and `additional origins`.
+After you create the application, you might want to set additional options like `refresh_token` and `additional origins`.
 
-If you want to request refresh_tokens and use them to renew the user's access_tokens without their interaction,
+If you want to request `refresh_tokens` and use them to renew the user's `access_tokens` without their interaction,
 enable them in the OIDC Configuration section by ticking the checkbox.
 
-When calling the userinfo_endpoint or any ZITADEL API, we will check if an origin header is sent. This is automatically done
-by the user agent. If one is sent we will check if the origin is allowed for your application. By default, all computed
-origins of the redirect_uri list are allowed.
-So if your native app is built with a JavaScript base framework like ReactNative and you only specified redirect_uris
-with a custom protocol, you will need to add the origin where the app is served from, e.g. `http://localhost:8100`.
+When you call the `userinfo_endpoint`, or any ZITADEL API, we check whether an origin header is sent.
+The user agent does this automatically.
+If an origin header is sent, we check whether the origin is allowed for your application.
+By default, all computed origins of the `redirect_uri` list are allowed.
+So if your native app is built with a JavaScript base framework, like ReactNative, and you specified only a `redirect_uri`
+with a custom protocol, you need to add the origin where the app is served from, e.g. `http://localhost:8100`.
 
 ### Additional parameters and customization
 
-There are additional parameters and values you can provide to satisfy your use case and to customize the user's authentication flow.
+To customize the user's authentication flow, there are additional parameters and values you can provide to satisfy your use case.
 Please check the [authorization_endpoint reference](/docs/apis/openidoauth/endpoints#authorization_endpoint) in the OAuth / OIDC documentation.
+
 
 ## Callback
 
-Regardless of a successful or error response from the authorization_endpoint, the authorization server will call your
-callback endpoint you provided by the `redirect_uri`.
+No matter whether the `authorization_endpoint` response returns a success message or an error,
+the authorization server will call the callback endpoint that you provided in the `redirect_uri`.
 
 :::note
-If the redirect_uri is not provided, was not registered or anything other prevents the auth server form returning the response to the client,
-the error will be display directly to the user on the auth server.
+If no `redirect_uri` is registered, or if anything else prevents the auth server from returning the response to the client,
+the error is displayed directly on the auth server.
 :::
 
-Upon successful authentication you'll be given a `code` and if provided the unmodified `state` parameter.
+Upon successful authentication, you'll be given a `code` and, if provided, the unmodified `state` parameter.
 You will need this `code` in the token request.
 
-If a parameter was missing, malformed or any other error occurred, your answer will contain an `error` stating the error type,
-possibly an `error_description` providing some information about the error and its reason and the `state` parameter.
+If a parameter is missing, malformed, or any other error occurred, your answer will contain an `error`.
+This error states the error type, and possibly gives an `error_description`, which provides some information about the error, its reason, and the `state` parameter.
 Check the [error response section](/docs/apis/openidoauth/endpoints#error-response) in the authorization_endpoint reference.
 
 ## Token request
 
-Next you will have to exchange the given `code` for the tokens. For this HTTP POST request (form-urlencoded) you will need to provide the following:
+Next you need to exchange the given `code` for the tokens.
+For this HTTP POST request (form-urlencoded), you need to provide the following:
 
-- code: the code that was issued from the authorization request
-- grant_type: must be `authorization_code`
-- redirect_uri: callback uri where the code was sent to. Must match exactly the redirect_uri of the authorization request
+- `code`: the code that was issued from the authorization request
+- `grant_type`: must be `authorization_code`
+- `redirect_uri`: callback URI where the code was sent to. Must match exactly the `redirect_uri` of the authorization request
 
 Depending on your authentication method you'll need additional headers and parameters:
 

--- a/docs/docs/guides/authentication/authmethods/pkcenative.mdx
+++ b/docs/docs/guides/authentication/authmethods/pkcenative.mdx
@@ -1,6 +1,6 @@
 #### redirect_uri
 
-Native clients might have to register multiple `redirect_uris`, as operating system have different requirements.
+Native clients might have to register more than one `redirect_uri`, as operating system have different requirements.
 Typically, you register a `redirect_uri` starting with a custom protocol, e.g. `ch.zitadel.app://callback`.
 You're also allowed to use http://localhost, http://127.0.0.1 and http:[::1] without specifying a port: `http://locahost/callback`.
 

--- a/docs/docs/guides/authentication/identity-brokering.md
+++ b/docs/docs/guides/authentication/identity-brokering.md
@@ -148,7 +148,7 @@ Your user now can choose Google to login instead of username/password or mfa.
 
 ## Summary
 
-* You can federate identities of all oAuth 2.0 compliant external identity providers.
+* You can federate identities of all OAuth 2.0 compliant external identity providers.
 * Configure the provider in your custom login policy.
 
 Where to go from here:

--- a/docs/docs/guides/authentication/identity-brokering.md
+++ b/docs/docs/guides/authentication/identity-brokering.md
@@ -64,7 +64,7 @@ Google Example:
 2. Select **+ CREATE CREDENTIALS**. Choose **OAuth client ID**.
 3. Choose **Web application** as the Application type and give it a name.
 4. Add the redirect URIs from above.
-5. Save the `clientid` and client secret.
+5. Save **Your Client ID** and **Your Client Secret**.
 
 ![Add new oAuth credentials in Google Console](/img/google_add_credentials.gif)
 
@@ -72,13 +72,13 @@ Google Example:
 
 1. Go to your organization settings by selecting **Organization** in the menu, or by following this link: <https://console.zitadel.ch/org>.
 2. Modify your login policy.
-3. As long as you have the default policy, you can't change the policy. To set your own settings, select **create custom**.
+3. As long as you have the default policy, you can't change the policy. To set your own settings, select **Create Custom Policy**.
 
 ![Add custom login policy](/img/console_org_custom_login_policy.gif)
 
 ### 3.Configure new identity provider
 
-1. Go to the identity providers section. Select **new**.
+1. Go to the identity providers section. Select **New**.
 2. Fill out the form:
    - Use the issuer, `clientid` and client secret provided by your provider
    - The scopes will be prefilled with `openid`, `profile` and `email`, because this information is relevant for ZITADEL.

--- a/docs/docs/guides/authentication/identity-brokering.md
+++ b/docs/docs/guides/authentication/identity-brokering.md
@@ -60,7 +60,7 @@ In this exercise, we will add a new Google identity provider to federate identit
 
 Google Example:
 
-1. Go to the Google Gloud Platform and choose youre project: <https://console.cloud.google.com/apis/credentials>
+1. Go to the Google Cloud Platform and choose your project: <https://console.cloud.google.com/apis/credentials>
 2. Select **+ CREATE CREDENTIALS**. Choose **OAuth client ID**.
 3. Choose **Web application** as the Application type and give it a name.
 4. Add the redirect URIs from above.

--- a/docs/docs/guides/authentication/identity-brokering.md
+++ b/docs/docs/guides/authentication/identity-brokering.md
@@ -12,7 +12,7 @@ title: Identity Brokering
         <td>
             In this module you will:
             <ul>
-                <li>Learn about Identity Providers</li>
+                <li>Learn about identity providers</li>
                 <li>Add a new identity provider</li>
                 <li>See an example with Google Login</li>
             </ul>

--- a/docs/docs/guides/authentication/identity-brokering.md
+++ b/docs/docs/guides/authentication/identity-brokering.md
@@ -53,8 +53,8 @@ In this exercise, we will add a new Google identity provider to federate identit
 
 1. Register an OIDC Client in your preferred provider.
 2. Make sure you add the ZITADEL callback redirect URIs.
-   https://accounts.zitadel.ch/register/externalidp/callback
-   https://accounts.zitadel.ch/login/externalidp/callback
+   - https://accounts.zitadel.ch/register/externalidp/callback  
+   - https://accounts.zitadel.ch/login/externalidp/callback
 
 > **Information:** Make sure the provider is OIDC 1.0 compliant with a proper Discovery Endpoint
 
@@ -66,7 +66,7 @@ Google Example:
 4. Add the redirect URIs from above.
 5. Save **Your Client ID** and **Your Client Secret**.
 
-![Add new oAuth credentials in Google Console](/img/google_add_credentials.gif)
+![Add new OAuth credentials in the Google console](/img/google_add_credentials.gif)
 
 ### 2. Add custom login policy on your organization
 
@@ -80,7 +80,7 @@ Google Example:
 
 1. Go to the identity providers section. Select **New**.
 2. Fill out the form:
-   - Use the issuer, `clientid` and client secret provided by your provider
+   - Use the issuer, `clientid` and `client secret` you get from your identity provider
    - The scopes will be prefilled with `openid`, `profile` and `email`, because this information is relevant for ZITADEL.
    - Choose what fields you like to map as the display name and username. The fields you can choose are `preferred_username` and `email`
      (Example: For Google, you should choose `email` for both fields)
@@ -128,7 +128,7 @@ Your user now can choose Google to login instead of username/password or mfa.
 * The issuer for your identity provider is <https://issuer.zitadel.ch>
     - [ ] yes
     - [ ] no
-* The identity provider has to be oAuth 2.0 compliant
+* The identity provider has to be OAuth 2.0 compliant
     - [ ] yes
     - [ ] no
 
@@ -140,7 +140,7 @@ Your user now can choose Google to login instead of username/password or mfa.
 * The issuer for your identity provider is https://issuer.zitadel.ch
     - [ ] yes
     - [x] no (The issuer is provided by your chosen identity provider. In the case of Google, it's https://accounts.google.com)
-* The identity provider has to be oAuth 2.0 compliant
+* The identity provider has to be OAuth 2.0 compliant
     - [x] yes
     - [ ] no
 

--- a/docs/docs/guides/authentication/identity-brokering.md
+++ b/docs/docs/guides/authentication/identity-brokering.md
@@ -41,7 +41,7 @@ _Federated identity management_ is an arrangement that is made between two or mo
 For example,
 if Google is configured as an identity provider on your organization, users can use their Google Account on the Login Screen of ZITADEL (1).
 ZITADEL redirects users to the login screen of Google, where they authenticate themselves, (2) and are sent back (3).
-Because Google is registered as a trusted identity provider, users can login in with the Google account after they link an existing ZITADEL Account, or after they register a new one with the claims provided by Google (4)(5).
+Because Google is registered as a trusted identity provider, users can log in with the Google account after they link an existing ZITADEL Account, or after they register a new one with the claims provided by Google (4)(5).
 
 ![Identity Brokering](/img/guides/identity_brokering.png)
 
@@ -52,7 +52,7 @@ In this exercise, we will add a new Google identity provider to federate identit
 ### 1. Create new OIDC Client
 
 1. Register an OIDC Client in your preferred provider.
-2. Make sure you add the ZITADEL callback redirect uris.
+2. Make sure you add the ZITADEL callback redirect URIs.
    https://accounts.zitadel.ch/register/externalidp/callback
    https://accounts.zitadel.ch/login/externalidp/callback
 
@@ -63,7 +63,7 @@ Google Example:
 1. Go to the Google Gloud Platform and choose youre project: <https://console.cloud.google.com/apis/credentials>
 2. Select **+ CREATE CREDENTIALS**. Choose **OAuth client ID**.
 3. Choose **Web application** as the Application type and give it a name.
-4. Add the redirect uris from above.
+4. Add the redirect URIs from above.
 5. Save the `clientid` and client secret.
 
 ![Add new oAuth credentials in Google Console](/img/google_add_credentials.gif)
@@ -81,7 +81,7 @@ Google Example:
 1. Go to the identity providers section. Select **new**.
 2. Fill out the form:
    - Use the issuer, `clientid` and client secret provided by your provider
-   - The scopes will be prefilled with `openid`, profile and email, because this information is relevant for ZITADEL.
+   - The scopes will be prefilled with `openid`, `profile` and `email`, because this information is relevant for ZITADEL.
    - Choose what fields you like to map as the display name and username. The fields you can choose are `preferred_username` and `email`
      (Example: For Google, you should choose `email` for both fields)
 3. Save your configuration

--- a/docs/docs/guides/authentication/identity-brokering.md
+++ b/docs/docs/guides/authentication/identity-brokering.md
@@ -14,7 +14,7 @@ title: Identity Brokering
             <ul>
                 <li>Learn about Identity Providers</li>
                 <li>Add a new identity provider</li>
-                <li>Example with Google Login</li>
+                <li>See an example with Google Login</li>
             </ul>
         </td>
     </tr>
@@ -30,27 +30,29 @@ title: Identity Brokering
 
 ## What is Identity Brokering and Federated Identities?
 
-Federated identity management is an arrangement built upon the trust between two or more domains. Users of these domains are allowed to access applications and services using the same identity.
-This identity is known as federated identity and the pattern behind this as identity federation.
+_Federated identity management_ is an arrangement built upon the trust between two or more domains.
+Users of these domains can access applications and services using the same identity.
+This identity is known as _federated identity_.
+The pattern behind it is known as _identity federation_.
 
-A service provider that specializes in brokering access control between multiple service providers (also referred to as relying parties) is called identity broker.
-Federated identity management is an arrangement that is made between two or more such identity brokers across organizations.
+An _identity broker_ is a service provider that specializes in brokering access control between multiple service providers (also referred to as relying parties).
+_Federated identity management_ is an arrangement that is made between two or more such identity brokers across organizations.
 
-Example:
-If Google is configured as identity provider on your organization, the user will get the option to use his Google Account on the Login Screen of ZITADEL (1).
-ZITADEL will redirect the user to the login screen of Google where he as to authenticated himself (2) and is sent back after he has finished that (3).
-Because Google is registered as trusted identity provider the user will be able to login in with the Google account after he linked an existing ZITADEL Account or just registered a new one with the claims provided by Google (4)(5).
+For example,
+if Google is configured as an identity provider on your organization, users can use their Google Account on the Login Screen of ZITADEL (1).
+ZITADEL redirects users to the login screen of Google, where they authenticate themselves, (2) and are sent back (3).
+Because Google is registered as a trusted identity provider, users can login in with the Google account after they link an existing ZITADEL Account, or after they register a new one with the claims provided by Google (4)(5).
 
 ![Identity Brokering](/img/guides/identity_brokering.png)
 
 ## Exercise: Register an external identity provider
 
-In this exercise we will add a new Google identity provider to federate identities with ZITADEL.
+In this exercise, we will add a new Google identity provider to federate identities with ZITADEL.
 
 ### 1. Create new OIDC Client
 
-1. Register an OIDC Client in your preferred provider
-2. Make sure you add the ZITADEL callback redirect uris
+1. Register an OIDC Client in your preferred provider.
+2. Make sure you add the ZITADEL callback redirect uris.
    https://accounts.zitadel.ch/register/externalidp/callback
    https://accounts.zitadel.ch/login/externalidp/callback
 
@@ -59,45 +61,48 @@ In this exercise we will add a new Google identity provider to federate identiti
 Google Example:
 
 1. Go to the Google Gloud Platform and choose youre project: <https://console.cloud.google.com/apis/credentials>
-2. Click on "+ CREATE CREDENTIALS" and choose "OAuth client ID"
-3. Choose Web application as Application type and give a name
-4. Add the redirect uris from above
-5. Save clientid and client secret
+2. Select **+ CREATE CREDENTIALS**. Choose **OAuth client ID**.
+3. Choose **Web application** as the Application type and give it a name.
+4. Add the redirect uris from above.
+5. Save the `clientid` and client secret.
 
 ![Add new oAuth credentials in Google Console](/img/google_add_credentials.gif)
 
 ### 2. Add custom login policy on your organization
 
-1. Go to your organization settings by clicking on "Organization" in the menu or using the following link: <https://console.zitadel.ch/org>
-2. Modify your login policy
-3. As long as you have the default policy, you can't change the policy. Click create custom policy to set your on settings.
+1. Go to your organization settings by selecting **Organization** in the menu, or by following this link: <https://console.zitadel.ch/org>.
+2. Modify your login policy.
+3. As long as you have the default policy, you can't change the policy. To set your own settings, select **create custom**.
 
 ![Add custom login policy](/img/console_org_custom_login_policy.gif)
 
 ### 3.Configure new identity provider
 
-1. Go to the identity providers section and click new
-2. Fill out the form
-   - Use the issuer, clientid and client secret provided by your provider
-   - The scopes will be prefilled with openid, profile and email, because this information is relevant for ZITADEL
-   - You can choose what fields you like to map as the display name and as username. The fields you can choose are preferred_username and email
-     (Example: For Google you should choose email for both fields)
+1. Go to the identity providers section. Select **new**.
+2. Fill out the form:
+   - Use the issuer, `clientid` and client secret provided by your provider
+   - The scopes will be prefilled with `openid`, profile and email, because this information is relevant for ZITADEL.
+   - Choose what fields you like to map as the display name and username. The fields you can choose are `preferred_username` and `email`
+     (Example: For Google, you should choose `email` for both fields)
 3. Save your configuration
-4. Link your new configuration to your login policy. By searching in the organization category you will get you own configuration. If you choose system you can link all predefined providers.
+4. Link your new configuration to your login policy.
+   Search the organization category to get your own configuration.
+   If you choose system you can link all predefined providers.
 
 ![Configure identity provider](/img/console_org_identity_provider.gif)
 
 ### 4.Send the primary domain scope on the authorization request
-ZITADEL will show a set of identity providers by default. This configuration can be changed by users with the [manager role] (https://docs.zitadel.ch/docs/concepts/zitadel/objects/managers) `IAM_OWNER`.
+ZITADEL shows a set of identity providers by default. This configuration can be changed by users with the [manager role] (https://docs.zitadel.ch/docs/concepts/zitadel/objects/managers) `IAM_OWNER`.
 
-An organization's login settings will be shown 
+An organization's login settings are shown:
 
-- as soon as the user has entered the loginname and ZITADEL can identitfy to which organization he belongs; or
+- as soon as users enter the `loginname`, and ZITADEL can identify which organizations they belong to; or
 - by sending a primary domain scope.
-To get your own configuration you will have to send the [primary domain scope](https://docs.zitadel.ch/docs/apis/openidoauth/scopes#reserved-scopes) in your [authorization request](https://docs.zitadel.ch/docs/guides/authentication/login-users/#auth-request) .
-The primary domain scope will restrict the login to your organization, so only users of your own organization will be able to login, also your branding and policies will trigger.
+To get your own configuration, send the [primary domain scope](https://docs.zitadel.ch/docs/apis/openidoauth/scopes#reserved-scopes) in your [authorization request](https://docs.zitadel.ch/docs/guides/authentication/login-users/#auth-request) .
+The primary domain scope restricts the login to your organization, so only users of your own organization can login.
+This also triggers your branding and policies.
 
-See the following link as an example. Users will be able to register and login to the organization that verified the @caos.ch domain only.
+See the following link as an example. Users can register and login to the organization that verified the `@caos.ch` domain only.
 ```
 https://accounts.zitadel.ch/oauth/v2/authorize?client_id=69234247558357051%40zitadel&scope=openid%20profile%20urn%3Azitadel%3Aiam%3Aorg%3Adomain%3Aprimary%3Acaos.ch&redirect_uri=https%3A%2F%2Fconsole.zitadel.ch%2Fauth%2Fcallback&state=testd&response_type=code&nonce=test&code_challenge=UY30LKMy4bZFwF7Oyk6BpJemzVblLRf0qmFT8rskUW0
 ```
@@ -110,11 +115,13 @@ Make sure to replace the domain `caos.ch` with your own domain to trigger the co
 
 :::caution
 
-This example uses the ZITADEL Cloud Application for demonstration. You need to create your own auth request with your applications parameters. Please see the docs to construct an [Auth Request](https://docs.zitadel.ch/docs/guides/authentication/login-users/#auth-request).
+This example uses the ZITADEL Cloud Application for demonstration.
+You need to create your own auth request with your applications parameters.
+Please see the docs to construct an [Auth Request](https://docs.zitadel.ch/docs/guides/authentication/login-users/#auth-request).
 
 :::
 
-Your user will now be able to choose Google for login instead of username/password or mfa.
+Your user now can choose Google to login instead of username/password or mfa.
 
 ## Knowledge Check
 
@@ -132,7 +139,7 @@ Your user will now be able to choose Google for login instead of username/passwo
 
 * The issuer for your identity provider is https://issuer.zitadel.ch
     - [ ] yes
-    - [x] no (The issuer is provided by your choosen identity provider. In the case of Google it's https://accounts.google.com)
+    - [x] no (The issuer is provided by your chosen identity provider. In the case of Google, it's https://accounts.google.com)
 * The identity provider has to be oAuth 2.0 compliant
     - [x] yes
     - [ ] no
@@ -141,8 +148,8 @@ Your user will now be able to choose Google for login instead of username/passwo
 
 ## Summary
 
-* You can federate identities of all oAuth 2.0 compliant external identity providers
-* Configure the provider in your custom login policy
+* You can federate identities of all oAuth 2.0 compliant external identity providers.
+* Configure the provider in your custom login policy.
 
 Where to go from here:
 

--- a/docs/docs/guides/authentication/login-users.mdx
+++ b/docs/docs/guides/authentication/login-users.mdx
@@ -40,7 +40,7 @@ The following diagram demonstrates a basic authorization_code flow:
 5. Your application calls on the registered callback path (`redirect_uri`) and will be provided an `authorization_code`.
 6. This `authorization_code` must then be sent together with your application's authentication (`client_id` + `client_secret`) to the token endpoint.
 7. In exchange, the Authorization Server (ZITADEL) returns an `access_token`, and, if requested, a `refresh_token`. In the case of OIDC, it returns an id_token as well.
-8. The `access_token` can then be used to call a Resource Server (API). The token is be sent as an Authorization Header.
+8. The `access_token` can then be used to call a Resource Server (API). The token is sent as an Authorization Header.
 
 This flow is the same when using PKCE or JWT with Private Key for authentication.
 

--- a/docs/docs/guides/authentication/login-users.mdx
+++ b/docs/docs/guides/authentication/login-users.mdx
@@ -38,7 +38,7 @@ The following diagram demonstrates a basic authorization_code flow:
 3. The Authorization Server (ZITADEL) sends an HTTP `302` to the user's browser, which redirects the user to the login UI.
 4. The user has to authenticate using the demanded auth mechanics.
 5. Your application calls on the registered callback path (`redirect_uri`) and will be provided an `authorization_code`.
-6. This `authorization_code` must then be sent together with your application's authentication (`client_id` + `client_secret`) to the token endpoint).
+6. This `authorization_code` must then be sent together with your application's authentication (`client_id` + `client_secret`) to the token endpoint.
 7. In exchange, the Authorization Server (ZITADEL) returns an `access_token`, and, if requested, a `refresh_token`. In the case of OIDC, it returns an id_token as well.
 8. The `access_token` can then be used to call a Resource Server (API). The token is be sent as an Authorization Header.
 

--- a/docs/docs/guides/authentication/login-users.mdx
+++ b/docs/docs/guides/authentication/login-users.mdx
@@ -64,7 +64,7 @@ This starts a wizard, asking you for an application name and a type.
 >
 <TabItem value="web">
 
-#### Authentication method
+### Authentication method
 
 After selecting WEB, choose an authentication method. We recommend using PKCE.
 For even better security, you could switch to JWT, or just rely on the standard Code Flow.

--- a/docs/docs/guides/authentication/login-users.mdx
+++ b/docs/docs/guides/authentication/login-users.mdx
@@ -37,8 +37,8 @@ The following diagram demonstrates a basic authorization_code flow:
 2. You create an authorization request to the authorization endpoint.
 3. The Authorization Server (ZITADEL) sends an HTTP `302` to the user's browser, which redirects the user to the login UI.
 4. The user has to authenticate using the demanded auth mechanics.
-5. Your application calls on the registered callback path (redirect_uri) and will be provided an authorization_code.
-6. This authorization_code must then be sent together with your applications authentication (`client_id` + `client_secret`) to the token endpoint_.
+5. Your application calls on the registered callback path (`redirect_uri`) and will be provided an `authorization_code`.
+6. This `authorization_code` must then be sent together with your application's authentication (`client_id` + `client_secret`) to the token endpoint).
 7. In exchange, the Authorization Server (ZITADEL) returns an `access_token`, and, if requested, a `refresh_token`. In the case of OIDC, it returns an id_token as well.
 8. The `access_token` can then be used to call a Resource Server (API). The token is be sent as an Authorization Header.
 

--- a/docs/docs/guides/authentication/login-users.mdx
+++ b/docs/docs/guides/authentication/login-users.mdx
@@ -48,7 +48,7 @@ This flow is the same when using PKCE or JWT with Private Key for authentication
 
 To create an application:
 
-1. Open your project in Console
+1. Open your project in the console
 2. Select the **New** button in the **Application** section.
 
 This starts a wizard, asking you for an application name and a type.
@@ -91,7 +91,7 @@ When selecting Native, the authentication method always needs to be PKCE.
 
 When selecting SPA, the recommended authentication method is again PKCE.
 All common Frameworks, like Angular, React, Vue.js, can successfully authenticate with PKCE.
-Our Managament UI Console, for instance, uses PKCE as well.
+The zitadel.ch Managament UI console, for instance, uses PKCE as well.
 
 <AuthMethods selected="spa" />
 </TabItem>

--- a/docs/docs/guides/authentication/login-users.mdx
+++ b/docs/docs/guides/authentication/login-users.mdx
@@ -78,7 +78,7 @@ This improves how the wizard guides you through the process:
 
 <TabItem value="native">
 
-#### Authentication method
+### Authentication method
 
 When selecting Native, the authentication method always needs to be PKCE.
 

--- a/docs/docs/guides/authentication/login-users.mdx
+++ b/docs/docs/guides/authentication/login-users.mdx
@@ -64,7 +64,7 @@ This starts a wizard, asking you for an application name and a type.
 >
 <TabItem value="web">
 
-### Authentication method
+### Web authentication methods
 
 After selecting WEB, choose an authentication method. We recommend using PKCE.
 For even better security, you could switch to JWT, or just rely on the standard Code Flow.
@@ -78,7 +78,7 @@ This improves how the wizard guides you through the process:
 
 <TabItem value="native">
 
-### Authentication method
+### Native authentication method
 
 When selecting Native, the authentication method always needs to be PKCE.
 
@@ -87,7 +87,7 @@ When selecting Native, the authentication method always needs to be PKCE.
 
 <TabItem value="spa">
 
-### Authentication method
+### SPA authentication methods
 
 When selecting SPA, the recommended authentication method is again PKCE.
 All common Frameworks, like Angular, React, Vue.js, can successfully authenticate with PKCE.

--- a/docs/docs/guides/authentication/login-users.mdx
+++ b/docs/docs/guides/authentication/login-users.mdx
@@ -1,5 +1,5 @@
 ---
-title: Login Users into your Application
+title: Authenticate your application's users
 ---
 
 import Tabs from "@theme/Tabs";
@@ -8,23 +8,24 @@ import AuthMethods from "./authmethods.mdx";
 
 ## Overview
 
-This guide will show you how to use ZITADEL to login users into your application (authentication).
-It will guide you step-by-step through the basics and point out on how to customize process.
+This guide shows you how to use ZITADEL to *authenticate* your app's users.
+That is, it shows you how to use ZITADEL to log users in to your app.
+It guides you step-by-step through the basics and points out on how to customize the process.
 
 ## OIDC / OAuth Flow
 
-OAuth and therefore OIDC know three different application types:
+OAuth (and therefore OIDC) recognize three different application types:
 
 - Web (Server-side web applications such as java, .net, ...)
-- Native (native, mobile or desktop applications)
+- Native (native, mobile, or desktop applications)
 - User Agent (single page applications / SPA, generally JavaScript executed in the browser)
 
-Depending on the app type you're trying to register, there are small differences.
-But regardless of the app type we recommend using Proof Key for Code Exchange (PKCE).
+Depending on the app type you're trying to register, there are small process differences.
+Regardless of the type you use, we recommend  *Proof Key for Code Exchange (PKCE)*.
+The [Recommended Authorization Flows](../authorization/oauth-recommended-flows#different-client-profiles)
+page explains why we recommend PKCE.
 
-Please read the following guide about the [different-client-profiles](../authorization/oauth-recommended-flows#different-client-profiles) and why to use PKCE.
-
-### Code Flow
+### About the authorization code flow
 
 For a basic understanding of OAuth and its flows, we'll briefly describe the most important flow: **Authorization Code**.
 
@@ -32,24 +33,25 @@ The following diagram demonstrates a basic authorization_code flow:
 
 ![Authorization Code Flow](/img/guides/auth_flow.png)
 
-1. When an unauthenticated user visits your application,
-2. you will create an authorization request to the authorization endpoint.
-3. The Authorization Server (ZITADEL) will send an HTTP 302 to the user's browser, which will redirect him to the login UI.
-4. The user will have to authenticate using the demanded auth mechanics.
-5. Your application will be called on the registered callback path (redirect_uri) and be provided an authorization_code.
-6. This authorization_code must then be sent together with you applications authentication (client_id + client_secret) to the token_endpoint
-7. In exchange the Authorization Server (ZITADEL) will return an access_token and if requested a refresh_token and in the case of OIDC an id_token as well
-8. The access_token can then be used to call a Resource Server (API). The token will be sent as Authorization Header.
+1. An unauthenticated user visits your application.
+2. You create an authorization request to the authorization endpoint.
+3. The Authorization Server (ZITADEL) sends an HTTP `302` to the user's browser, which redirects the user to the login UI.
+4. The user has to authenticate using the demanded auth mechanics.
+5. Your application calls on the registered callback path (redirect_uri) and will be provided an authorization_code.
+6. This authorization_code must then be sent together with your applications authentication (`client_id` + `client_secret`) to the token endpoint_.
+7. In exchange, the Authorization Server (ZITADEL) returns an `access_token`, and, if requested, a `refresh_token`. In the case of OIDC, it returns an id_token as well.
+8. The `access_token` can then be used to call a Resource Server (API). The token is be sent as an Authorization Header.
 
 This flow is the same when using PKCE or JWT with Private Key for authentication.
 
 ## Create Application
 
-To create an application, open your project in Console and start by clicking on the "New" button in the Application section.
+To create an application:
 
-#### Application type
+1. Open your project in Console
+2. Select the **New** button in the **Application** section.
 
-This will start a wizard asking you for an application name and a type.
+This starts a wizard, asking you for an application name and a type.
 
 <Tabs
     groupId="app-type"
@@ -64,11 +66,12 @@ This will start a wizard asking you for an application name and a type.
 
 #### Authentication method
 
-After selecting WEB, you'll next have to choose an authentication method. As mentioned before we recommend using PKCE.
-For even better security you could switch to JWT or just rely on the standard Code Flow. For security reasons we don't
-recommend using POST and will not cover it in this guide.
+After selecting WEB, choose an authentication method. We recommend using PKCE.
+For even better security, you could switch to JWT, or just rely on the standard Code Flow.
+For security reasons, we don't recommend using POST and do not cover it in this guide.
 
-Please change the authentication method here as well, if you did so in the wizard, so we can better guide you through the process:
+If you changed the authentication method in the wizard, change it here as well.
+This improves how the wizard guides you through the process:
 
 <AuthMethods selected="web" />
 </TabItem>
@@ -77,7 +80,7 @@ Please change the authentication method here as well, if you did so in the wizar
 
 #### Authentication method
 
-When selecting Native the authentication method always needs to be PKCE.
+When selecting Native, the authentication method always needs to be PKCE.
 
 <AuthMethods selected="native" />
 </TabItem>
@@ -86,8 +89,9 @@ When selecting Native the authentication method always needs to be PKCE.
 
 #### Authentication method
 
-When selecting SPA the recommended authentication method is again PKCE. All common Frameworks like Angular, React, Vue.js and so on
-are able to successfully authenticate with PKCE. Our Managament UI Console for instance uses PKCE as well.
+When selecting SPA, the recommended authentication method is again PKCE.
+All common Frameworks, like Angular, React, Vue.js, can successfully authenticate with PKCE.
+Our Managament UI Console, for instance, uses PKCE as well.
 
 <AuthMethods selected="spa" />
 </TabItem>

--- a/docs/docs/guides/authentication/login-users.mdx
+++ b/docs/docs/guides/authentication/login-users.mdx
@@ -87,7 +87,7 @@ When selecting Native, the authentication method always needs to be PKCE.
 
 <TabItem value="spa">
 
-#### Authentication method
+### Authentication method
 
 When selecting SPA, the recommended authentication method is again PKCE.
 All common Frameworks, like Angular, React, Vue.js, can successfully authenticate with PKCE.

--- a/docs/docs/guides/authentication/serviceusers.md
+++ b/docs/docs/guides/authentication/serviceusers.md
@@ -35,9 +35,9 @@ import UserDescription from '../../concepts/structure/_user_description.mdx';
 
 ## Exercise: Create a Service User
 
-1. Navigate to Service Users
-2. Click on **New**
-3. Enter a user name and a display name
+1. Navigate to Service Users.
+2. Click on **New**.
+3. Enter a user name and a display name.
 
 ![Create new service user](/img/console_serviceusers_create.gif)
 
@@ -45,27 +45,32 @@ import UserDescription from '../../concepts/structure/_user_description.mdx';
 
 In ZITADEL we use the `private_jwt` (**“JWT bearer token with private key”**, [RFC7523](https://tools.ietf.org/html/rfc7523)) authorization grant for this non-interactive authentication.
 
-You need to follow these steps to authenticate a service user and receive a access token:
+To authenticate a service user and receive a access token, follow these steps:
 
 1. Generate a private-public key pair in ZITADEL
-2. Create a JSON Web Token (JWT) and sign with private key
+2. Create a JSON Web Token (JWT) and sign with your private key
 3. With this JWT, request an OAuth token from ZITADEL
 
-With this token you can make subsequent requests, just like a human user.
+With this token, you can make subsequent requests, just like a human user.
 
 ## Exercise: Get an access token
 
-In this exercise we will authenticate a service user and receive an access_token to use against a API.
+In this exercise we will authenticate a service user and receive an `access_token` to use against a API.
 
 > **Information:** Are you stuck? Don't hesitate to reach out to us on [Github Discussions](https://github.com/caos/zitadel/discussions) or [contact us](https://zitadel.ch/contact/) privately.
 
 ### 1. Generate a private-public key pair in ZITADEL
 
-Select your service user and in the section KEYS click **New**. Enter an expiration date and click **Add**. Make sure to download the json by clicking **Download**.
+1. Select your service user and in the section KEYS, select **New**.
+1. Enter an expiration date and select **Add**.
+1. Make sure to download the JSON by selecting **Download**.
 
 ![Create private key](/img/console_serviceusers_new_key.gif)
 
-The downloaded json should look something like outlined below. The value of `key` contains the *private* key for your service account. Please make sure to keep this key securely stored and handle with care. The public key is automatically stored in ZITADEL.
+The downloaded json should look something like the following snippet.
+The value of `key` contains the *private* key for your service account.
+Make sure to keep this key securely stored and handle it with care.
+The public key is automatically stored in ZITADEL.
 
 ```json
 {
@@ -115,7 +120,7 @@ If you use Go, you might want to use the [provided tool](https://github.com/caos
 
 ### 3. With this JWT, request an OAuth token from ZITADEL
 
-With the encoded JWT from the prior step, you will need to craft a POST request to ZITADEL's token endpoint:
+With the encoded JWT from the prior step, craft a POST request to ZITADEL's token endpoint:
 
 ```bash
 curl --request POST \
@@ -145,7 +150,7 @@ Content-Type: application/json
 
 ### 4. Verify that you have a valid access token
 
-For this example let's call the userinfo endpoint to verfiy that our access token works.
+For this example, call the `userinfo` endpoint to verfiy that our access token works.
 
 ```bash
 curl --request POST \
@@ -198,9 +203,9 @@ Content-Type: application/json
 
 ## Summary
 
-* With service users you can secure machine-to-machine communication
-* Because there is no interactive logon, you need to use a JWT signed with your private key to authorize the user
-* After successful authorization you can use an access token like for human users
+* With service users, you can secure machine-to-machine communication.
+* Because there is no interactive login, you need to use a JWT signed with your private key to authorize the user.
+* After successful authorization, you can use an access token like you would for human users.
 
 Where to go from here:
 

--- a/docs/docs/guides/authentication/serviceusers.md
+++ b/docs/docs/guides/authentication/serviceusers.md
@@ -13,7 +13,7 @@ title: Service Users
             In this module you will:
             <ul>
                 <li>Learn about Service Users</li>
-                <li>Create a Service User in ZITADEL Console</li>
+                <li>Create a Service User in the ZITADEL console</li>
                 <li>Authorize a Service User with JWT signed with your private key</li>
             </ul>
         </td>

--- a/docs/docs/guides/authentication/serviceusers.md
+++ b/docs/docs/guides/authentication/serviceusers.md
@@ -45,10 +45,10 @@ import UserDescription from '../../concepts/structure/_user_description.mdx';
 
 In ZITADEL we use the `private_jwt` (**“JWT bearer token with private key”**, [RFC7523](https://tools.ietf.org/html/rfc7523)) authorization grant for this non-interactive authentication.
 
-To authenticate a service user and receive a access token, follow these steps:
+To authenticate a service user and receive an access token, follow these steps:
 
 1. Generate a private-public key pair in ZITADEL
-2. Create a JSON Web Token (JWT) and sign with your private key
+2. Create a JSON Web Token (JWT) and sign it with your private key
 3. With this JWT, request an OAuth token from ZITADEL
 
 With this token, you can make subsequent requests, just like a human user.

--- a/docs/docs/guides/authorization/oauth-recommended-flows.md
+++ b/docs/docs/guides/authorization/oauth-recommended-flows.md
@@ -29,7 +29,7 @@ title: Recommended authorization flows
 
 ## Introduction
 
-Before we set up our first application within ZITADEL, we need outline the basics of how to authorize with OpenID Connect 1.x and OAuth 2.x.
+Before we set up our first application within ZITADEL, we need to outline the basics of how to authorize with OpenID Connect 1.x and OAuth 2.x.
 
 ZITADEL makes no assumptions about the application type that you are going to integrate.
 Therefore you must choose an appropriate method to authorize your users (i.e. define an *authentication flow*).

--- a/docs/docs/guides/authorization/oauth-recommended-flows.md
+++ b/docs/docs/guides/authorization/oauth-recommended-flows.md
@@ -5,7 +5,7 @@ title: Recommended authorization flows
 <table class="table-wrapper">
     <tr>
         <td>Description</td>
-        <td>Learn about the different authentication flows and which flow we recommend you should use for your application.</td>
+        <td>Learn about the different authentication flows and about the flow that we recommend for your application.</td>
     </tr>
     <tr>
         <td>Learning Outcomes</td>
@@ -29,52 +29,70 @@ title: Recommended authorization flows
 
 ## Introduction
 
-Before we get into setting up our first application within ZITADEL, we need to go through some basics on how to obtain an authorization with OpenID Connect 1.x and OAuth 2.x.
+Before we set up our first application within ZITADEL, we need outline the basics of how to authorize with OpenID Connect 1.x and OAuth 2.x.
 
-ZITADEL does not make assumptions about the application type you are about to integrate. Therefore you must qualify and define an appropriate method for your users to gain authorization to access your application (“authentication flow”). Your choice depends on the application’s ability to maintain the confidentiality of client credentials and the technological capabilities of your application. If you choose a deprecated or unfeasible flow to obtain authorization for your application, your users’ credentials may be compromised.
+ZITADEL makes no assumptions about the application type that you are going to integrate.
+Therefore you must choose an appropriate method to authorize your users (i.e. define an *authentication flow*).
 
-We invite you to further explore the different authorization flows in the OAuth 2.x standard. For the start we assume that you have a brand-new application (ie. without legacy requirements) and you found an reliable SDK/Library that does the heavy lifting for you.
+What you choose depends on your application’s ability to keep client credentials confidential, and on the app's technological capabilities.
+If you chose a deprecated or unfeasible flow to obtain authorization for your application, you might compromise your users' credentials.
 
-So this module will only go over the basics and explain why we recommend the flow “Authorization Flow with PKCE” as default for most applications. We will also cover the case of machine-to-machine communication, ie. where there is no interactive login. Further we will guide you to further reading viable alternatives, if the default flow is not feasible.
+We invite you to explore the different authorization flows in the OAuth 2.x standard.
+At the start, we assume that you have a brand-new application (ie. without legacy requirements),
+and that you found a reliable SDK/Library that does the heavy lifting for you.
+
+This module covers only the basics.
+It explains why we recommend the flow “Authorization Flow with PKCE” as default for most applications.
+We also cover the case of machine-to-machine communication, ie. where there is no interactive login.
+For cases where the default flow is not feasible.
 
 ## Basics of Federated Identity
 
-Although Federated Identities are not a new concept ([RFC 6749](https://tools.ietf.org/html/rfc6749), “The OAuth 2.0 Authorization Framework” was released in 2012) it is important to highlight the difference between the traditional client-server authentication model and the concept of delegated authorization and authentication.
+Federated Identities are not a new concept.
+[RFC 6749](https://tools.ietf.org/html/rfc6749),
+“The OAuth 2.0 Authorization Framework,” was published in 2012.
+Nevertheless, it is important to highlight the difference between the traditional client-server authentication model and the concept of delegated authorization and authentication.
 
-The aforementioned RFC provides us with some [problems and limitations](https://tools.ietf.org/html/rfc6749#section-1) of the client-server authentication, where a client requests a protected resource on the server by authenticating with the user’s credentials:
+In client-server authentication, a client requests a protected resource on the server by authenticating with the user’s credentials.
+The aforementioned RFC describes some [problems and limitations](https://tools.ietf.org/html/rfc6749#section-1) of this approach: 
 
-* Applications need to store users credentials (eg, password) for future use; compromise of any application results in compromise of the end-users credentials
-* Servers are required to support password authentication
-* Without means of limiting scope when providing the user’s credentials, the application gains overly broad access to protected resources
-* Users cannot revoke access for a single application, but only for all by changing credentials
+* Applications need to store users credentials (eg, password) for future use; compromising any application also compromises the end-user credentials.
+* Servers must support password authentication.
+* If an application cannot limit scope when providing the user’s credentials, the application gains overly broad access to protected resources.
+* Users cannot revoke access for a single application, but only for all (by changing credentials).
 
 So what do we want to achieve with delegated authentication?
 
-* Instead of implementing authentication on each server and trusting each server
-  * Users only **authenticate** with a trusted server (ie. ZITADEL), that validates the user’s identity through a challenge (eg, multiple authentication factors) and issues an **ID token** (OpenID Connect 1.x)
-  * Applications have means of **validating the integrity** of presented access and ID tokens
+* Instead of implementing authentication on each server and trusting each server:
+  * Users *authenticate* only with a trusted server (ie. ZITADEL), which validates the user’s identity through a challenge (eg, multiple authentication factors) and issues an *ID token* (OpenID Connect 1.x).
+  * Applications have a way to *validate the integrity* of the presented access and ID tokens.
 
-* Instead of sending around the user’s credentials
-  * Clients may access protected resources with an **access token** that is only valid for specific scope and limited lifetime (OAuth 2.x)
-  * Users have to **authorize** applications to access certain [**scopes**](https://docs.zitadel.ch/architecture#Scopes) (eg, email address or custom roles). Applications can request [**claims**](https://docs.zitadel.ch/architecture#Claims) (key:value pairs, eg email address) for the authorized scopes with the access token or ID token from ZITADEL
-  * Access tokens are bearer tokens, meaning that possession of the token provides access to a resource. But the tokens expire frequently and the application must request a new access token via **refresh token** or the user must reauthenticate
+* Instead of sending around the user’s credentials:
+  * Clients can use an *access token* to access protected resources. This token is valid only for a specific scope and lifetime (OAuth 2.x).
+  * Users have to *authorize* applications to access certain [**scopes**](https://docs.zitadel.ch/architecture#Scopes) (e.g. email address or custom roles). Applications can request [**claims**](https://docs.zitadel.ch/architecture#Claims) (key:value pairs, e.g. email address) for the authorized scopes with the access token or ID token from ZITADEL
+  * Access tokens are bearer tokens.
+   They provide access to whoever possesses the token. But the tokens expire frequently and the application must either request a new access token via *refresh token*, or have the user reauthenticate.
 
 ![Overview federated identities](/img/guides/consulting_federated_identities_basics.png)
 
-This is where the so-called “flows” come into play: There are a number of different flows on how to handle the process from authentication, over authorization, getting tokens and requesting additional information about the user.
+This is where the so-called “flows” come into play: There are a number of different flows to handle the process of authenticating, authorizating, getting tokens, and requesting additional user information.
 
-Maybe interesting to mention is that we are mostly concerned with choosing the right OAuth 2.x flows (alas “authorization”). OpenID Connect extends the OAuth 2.x flow with useful features like endpoint discovery (where to ask), ID Token (who is the user, when and how did she authenticate), and UserInfo Endpoint (getting additional information about the user).
+It is worth mentioning that we are mostly concerned with choosing the right OAuth 2.x flows (“authorization”).
+OpenID Connect extends the OAuth 2.x flow with useful features like:
+* Endpoint discovery&mdash;where to ask?
+* ID Tokens&mdash;who are the users, when and how did they authenticate?
+* UserInfo Endpoint&mdash;what additional information is there about the user?
 
 ## Different client profiles
 
-As mentioned in the beginning of this module, there are two main determinants for choosing the optimal authorization flow:
+As mentioned earlier in this module, two main considerations determine the optimal authorization flow:
 
-1. Client’s ability to maintain the confidentiality of client credentials
+1. The client’s ability to maintain client-credential confidentiality. 
 2. Technological limitations
 
 OAuth 2.x defines two [client types](https://tools.ietf.org/html/rfc6749#section-2.1) based on their ability to maintain the confidentiality of their client credentials:
 
-* Confidential: Clients capable of maintaining the confidentiality of their credentials (e.g., client implemented on a secure server with restricted access to the client credentials), or capable of secure client authentication using other means.
+* Confidential: Clients capable of maintaining the confidentiality of their credentials (e.g., the client is implemented on a secure server, with restricted access to client credentials), or capable of securing client authentication using other means.
 * Public: Clients incapable of maintaining the confidentiality of their credentials (e.g., clients executing on the device used by the resource owner, such as an installed native application or a web browser-based application), and incapable of secure client authentication via any other means.
 
 The following table gives you a brief overview of different client profiles.
@@ -97,41 +115,46 @@ The following table gives you a brief overview of different client profiles.
 	<tr>
 		<td rowspan="2">Confidential</td>
 		<td>Web</td>
-		<td>Server-side web applications such as java, .net, …</td>
+		<td>Server-side web applications such as java, .net, etc.</td>
 	</tr>
 	<tr>
 		<td>Machine-to-Machine</td>
-		<td>APIs, generally services without direct user-interaction at the authorization server</td>
+		<td>APIs, generally services without direct user-interaction, on the authorization server</td>
 	</tr>
 </table>
 
 ## Our recommended authorization flows
 
-We recommend using the flow **“Authorization Code with Proof Key of Code Exchange (PKCE)”** ([RFC7636](https://tools.ietf.org/html/rfc7636)) for **User-Agent**, **Native**, and **Web** clients.
+For User-Agent, Native, and Web clients,
+**we recommend using the flow “Authorization Code with Proof Key of Code Exchange (PKCE)”** ([RFC7636](https://tools.ietf.org/html/rfc7636)).
 
-If you don’t have any technical limitations, you should favor the flow Authorization Code with PKCE over other methods. The PKCE part makes the flow resistant against authorization code interception attack as described well in RFC7636.
+If you don’t have any technical limitations, favor the flow *Authorization Code with PKCE* over other methods.
+The PKCE part makes the flow resistant to authorization code interception attacks, as described well in RFC7636.
 
 *So what about APIs?*
 
-We recommend using **“JWT bearer token with private key”** ([RFC7523](https://tools.ietf.org/html/rfc7523)) for Machine-to-Machine clients.
+**For APIs, we recommend using _JWT bearer token with private key_ ([RFC7523](https://tools.ietf.org/html/rfc7523)) for Machine-to-Machine clients.
 
-What this means is that you have to send an JWT token, containing the [standard claims for access tokens](https://docs.zitadel.ch/architecture#Claims) and that is signed with your private key, to the token endpoint to request the access token. We will see how this works in another module about Service Accounts.
+What this means is that, to request the access token, you must send a JWT token to the token endpoint.
+This JWT must contain the [standard claims for access tokens](https://docs.zitadel.ch/architecture#Claims), and be signed with your private key.
+We will see how this works in another module about Service Accounts.
 
 If you don’t have any technical limitations, you should prefer this method over other methods.
 
-A JWT with a private key can also be used with client profile web to further enhance security.
+To further enhance security, you can also use a JWT with a private key with a client profile web.
 
-In case you need alternative flows and their advantages and drawbacks, there will be a module to outline more methods and our recommended fallback strategy per client profile that are available in ZITADEL.
+In some cases, you might need alternative flows, with their advantages and drawbacks.
+There will be a module that outlines more methods and our recommended fallback strategies per client profile available in ZITADEL.
 
 ## Knowledge Check (3)
 
-* With federated identities the user sends credentials to the server holding the protected resource
+* With federated identities the user sends credentials to the server holding the protected resource.
     - [ ] yes
     - [ ] no
-* ZITADEL will discover your client profile automatically and set the correct flow
+* ZITADEL discovers your client profile automatically and sets the correct flow.
     - [ ] yes
     - [ ] no
-* When working with APIs / machine-to-machine communication its recommended to exchange a JWT that is singed with your private key for an access token
+* When working with APIs / machine-to-machine communication, it is recommended to exchange a JWT, singed with your private key, for an access token
     - [ ] yes
     - [ ] no
 
@@ -142,10 +165,10 @@ In case you need alternative flows and their advantages and drawbacks, there wil
 
 * With federated identities the user sends credentials to the server holding the protected resource
     - [ ] yes
-    - [x] no (Users are authenticated against a centralized IDP, only access tokens are send to the requested resources)
+    - [x] no (Users are authenticated against a centralized IDP, only access tokens are sent to the requested resources).
 * ZITADEL will discover your client profile automatically and set the correct flow
     - [ ] yes
-    - [x] no (ZITADEL does not make any assumptions about your application’s requirements)
+    - [x] no (ZITADEL does not make any assumptions about your application’s requirements).
 * When working with APIs / machine-to-machine communication its recommended to exchange a JWT that is singed with your private key for an access token
     - [x] yes
     - [ ] no
@@ -154,10 +177,10 @@ In case you need alternative flows and their advantages and drawbacks, there wil
 
 ## Summary (3)
 
-* Federated Identities solve key problems and challenges with traditional server-client architecture
-* Use “Authorization Code with Proof Key of Code Exchange (PKCE)” for User-Agent, Native, and Web clients
-* “JWT bearer token with private key” for Machine-to-Machine clients
-* There are alternative flows and fallback strategies supported by ZITADEL, if these flows are technically not possible
+* Federated Identities solve key problems and challenges with traditional server-client architecture.
+* Use _Authorization Code with Proof Key of Code Exchange (PKCE)_ for User-Agent, Native, and Web clients.
+* Use a *JWT bearer token with private key* for Machine-to-Machine clients.
+* If these flows are technically not possible, ZITADEL supports fallback flows and strategies.
 
 Where to go from here
 

--- a/docs/docs/guides/basics/get-started.mdx
+++ b/docs/docs/guides/basics/get-started.mdx
@@ -53,7 +53,7 @@ For example, you can permit managers to edit project settings, and permit others
 After creating your project, you can start integrating your applications.
 
 1. [Choose your project](https://console.zitadel.ch/projects).
-1. On the top of the page, add client.
+1. Add a client by selecting **New** In the **APPLICATIONS** section on the top of the page.
 
 The wizard provides some guidance what about client is right for you.
 If you are still unsure, consult our [Guide Project](projects).

--- a/docs/docs/guides/basics/get-started.mdx
+++ b/docs/docs/guides/basics/get-started.mdx
@@ -36,7 +36,7 @@ To do so, refer to [the Quickstart guides](../../quickstarts/introduction).
 
 ### Verify your domain name (optional)
 
-If you verify a domain, your organisation's users can use this domain as the **preferred logonname**.
+If you verify a domain, your organisation's users can use this domain as the *preferred loginname*.
 
 ### Elect Managers
 

--- a/docs/docs/guides/basics/get-started.mdx
+++ b/docs/docs/guides/basics/get-started.mdx
@@ -4,23 +4,30 @@ title: Get started
 
 import Column from "../../../src/components/column";
 
-Most applications need to know the identity of a user allowing to securely store user data in the cloud and provide the same personalised experience across all of the user's devices.
+Authentication is how an application can verify that the user is who they claim to be.
+Most applications need authentication to securely store user data in the cloud and to provide the same personalized experience across all user devices.
 
-ZITADEL's authentication provides backend services, easy-to-use SDKs, and ready-made UI libraries to authenticate users in your application. It supports authentication using passwords and applies additional security with the help of a second factor, for example OTP, to ensure a safe and secure access.
-It additionally leverages industry standards like OAuth 2.0 and OpenID Connect such that it can be easily integrated in your custom backend.
+ZITADEL's authentication provides backend services, easy-to-use SDKs, and ready-made UI libraries to authenticate users in your application.
 
-This provides a quick start guide on how to register your organization as well as creating your first project.
+It supports authentication using passwords,
+with additional support for two-factor authentication methods like One Time Password (OTP). 
+It also leverages industry standards like OAuth 2.0 and OpenID Connect.
+This lets you easily integrate ZITADEL in your custom backend.
 
 ## Trying out ZITADEL on zitadel.ch
+
+To register your organization and create your first project, follow this quick-start guide.
 
 <Column>
 <div>
 
-To create a ZITADEL project, you have to register as an organization first. Click [here](https://accounts.zitadel.ch/register/org) to register.
-You will receive an email prompting you to verify your mail.
-Then go to your [Console Projects](https://console.zitadel.ch/projects) view and create a new project.
+1. Follow this link to [register your organization](https://accounts.zitadel.ch/register/org).
+You will receive an email to verify your account.
 
-Now you can proceed adding users to your organization as well as integrating your applications. We refer to our guides as well as our [Quickstarts](../../quickstarts/introduction) to do so.
+2. Go to your [Console Projects](https://console.zitadel.ch/projects) view and create a new project.
+
+Now you can add users to your organization, and integrate your applications.
+To do so, refer to [the Quickstart guides](../../quickstarts/introduction).
 
 </div>
 <img width="400px" src="/img/accounts_org_register_light.png" alt="register view"/>
@@ -28,19 +35,26 @@ Now you can proceed adding users to your organization as well as integrating you
 
 ### Verify your domain name (optional)
 
-If you verify a domain you get the benefit that your organisations users can use this domain as the **preferred logonname**.
+If you verify a domain, your organisation's users can use this domain as the **preferred logonname**.
 
 ### Elect Managers
 
-ZITADEL allows you to give other users control over ZITADEL Console itself. This can be restricted to some kind of write and/or read. This can be especially useful for directing administration over several users. You can have managers able to edit project settings and others able to create/add users only.
-Read the [guides](../overview) for more information.
+ZITADEL allows you to give other users control over the ZITADEL Console itself.
+You can restrict this access to `read` or `write`.
+This is especially useful to granularly assign administration responsibilities to different users.
+For example, you can permit managers to edit project settings, and permit others to only create users.
+[The guides provide more information](../overview).
 
-> Note: ZITADEL Managers are always located on the right sidepanel of console.
+> Note: ZITADEL Managers are always located on the right sidepanel of the console.
 
 ### Integrating an application
 
-After creating your project you can start integrating your applications.
-After choosing your [project](https://console.zitadel.ch/projects) add a client application on the top of the page.
-The wizard should provide some guidance what client is the proper for you. If you are still unsure consult our [Guide Project](projects).
+After creating your project, you can start integrating your applications.
+
+1. [Choose your project](https://console.zitadel.ch/projects).
+1. On the top of the page, add client.
+
+The wizard provides some guidance what about client is right for you.
+If you are still unsure, consult our [Guide Project](projects).
 
 ## Learn more

--- a/docs/docs/guides/basics/get-started.mdx
+++ b/docs/docs/guides/basics/get-started.mdx
@@ -4,15 +4,16 @@ title: Get started
 
 import Column from "../../../src/components/column";
 
-Authentication is how an application can verify that the user is who they claim to be.
+*Authentication* is how an application can verify that its users are who they claim to be.
 Most applications need authentication to securely store user data in the cloud and to provide the same personalized experience across all user devices.
 
-ZITADEL's authentication provides backend services, easy-to-use SDKs, and ready-made UI libraries to authenticate users in your application.
+ZITADEL's authentication provides backend services, easy-to-use SDKs, and ready-made UI libraries.
 
-It supports authentication using passwords,
-with additional support for two-factor authentication methods like One Time Password (OTP). 
-It also leverages industry standards like OAuth 2.0 and OpenID Connect.
-This lets you easily integrate ZITADEL in your custom backend.
+It supports password authentication,
+with two-factor authentication methods like One Time Password (OTP).
+You easily integrate ZITADEL in your custom backend,
+as it leverages industry standards like OAuth 2.0 and OpenID Connect.
+
 
 ## Trying out ZITADEL on zitadel.ch
 

--- a/docs/docs/guides/basics/get-started.mdx
+++ b/docs/docs/guides/basics/get-started.mdx
@@ -25,7 +25,7 @@ To register your organization and create your first project, follow this quick-s
 1. Follow this link to [register your organization](https://accounts.zitadel.ch/register/org).
 You will receive an email to verify your account.
 
-2. Go to your [Console Projects](https://console.zitadel.ch/projects) view and create a new project.
+2. Go to your [projects](https://console.zitadel.ch/projects) view and create a new project.
 
 Now you can add users to your organization, and integrate your applications.
 To do so, refer to [the Quickstart guides](../../quickstarts/introduction).
@@ -40,7 +40,7 @@ If you verify a domain, your organisation's users can use this domain as the **p
 
 ### Elect Managers
 
-ZITADEL allows you to give other users control over the ZITADEL Console itself.
+ZITADEL allows you to give other users control over the ZITADEL console itself.
 You can restrict this access to `read` or `write`.
 This is especially useful to granularly assign administration responsibilities to different users.
 For example, you can permit managers to edit project settings, and permit others to only create users.

--- a/docs/docs/guides/basics/organizations.mdx
+++ b/docs/docs/guides/basics/organizations.mdx
@@ -3,11 +3,11 @@ title: Organizations
 ---
 
 
-| | |
-| --- | --- |
-| Description | Learn how ZITADEL is structured around Organizations and how to create your organization and verify a domain to use with that new organization. |
-| Learning Outcomes | In this module you will: <ul><li>Learn about organizations</li><li>Create a new organization</li><li>Verify your domain name </li></ul> |
-|Prerequisites|None|
+|                   |                                                                                                                                                 |
+|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| Description       | Learn about ZITADEL's Organization-centered structure. See how to create your organization and verify a domain to use with that new organization. |
+| Learning Outcomes | In this module you will: <ul><li>Learn about organizations</li><li>Create a new organization</li><li>Verify your domain name </li></ul>         |
+| Prerequisites     | None                                                                                                                                            |
 
 ## What is an organization?
 
@@ -16,17 +16,19 @@ import Column from '../../../src/components/column';
 
 <OrgDescription name="OrgDescription" />
 
-There are several more modules in our documentation to go into more detail regarding organization management, projects, clients, and users. But first let’s create a new organization and verify your domain name.
+First, let’s create a new organization and verify your domain name.
+Afterwards, you can learn more in several other documentation modules, which detail how to manage organizations, projects, clients, and users.
 
 ## Exercise - Create a new organization
 
-To register your organization and create a user for ZITADEL, visit zitadel.ch or directly <https://accounts.zitadel.ch/register/org> and fill in the required information.
+To register your organization and create a user for ZITADEL, visit zitadel.ch or go directly <https://accounts.zitadel.ch/register/org> and fill in the required information.
 
 ![Register new Organization](/img/console_org_register.png)
 
 <Column>
 <div>
-  If you already have an existing login for zitadel.ch, you need to visit the console, then click on your organization’s name in the upper left corner, and then select “New organization”.
+  If you already have an existing login for zitadel.ch, you need to visit the console.
+  Then select your organization’s name in the upper-left corner, and **New organization**.
 </div>
 
 <img src="/img/console_org_select.png" alt="Select Organization"/>
@@ -34,28 +36,41 @@ To register your organization and create a user for ZITADEL, visit zitadel.ch or
 
 ## How ZITADEL handles usernames
 
-As we mentioned before, each organization has its own pool of usernames, which includes human and service.
+As we mentioned before, each organization has its own pool of usernames.
+These usernames include both humans and services.
 
-This means that, for example a user with the username road.runner, can only exist once in an organization called ACME. ZITADEL will automatically generate a "logonname" for each  consisting of `{username}@{domainname}.{zitadeldomain}`, in our example road.runner@acme.zitadel.ch.
+For example the username `road.runner` can only exist once and only for one user in an organization called ACME.
+ZITADEL will automatically generate a *logonname* for each  consisting of `{username}@{domainname}.{zitadeldomain}`.
+In this example, the *loggonname*` would be `road.runner@acme.zitadel.ch`.
 
-When you verify your domain name, then ZITADEL will generate additional logonames for each user with the verified domain. If our example organization would own the domain acme.ch and verify within the organization ACME, then the resulting logonname in our example would be road.runner@acme.ch in addition to the already generated road.runner@acme.zitadel.ch. The user can now use either logonname to authenticate with your application.
+When you verify your domain name, ZITADEL generates additional logonnames for each user with the verified domain.
+If ACME owned the domain acme.ch and verified this domain for the organization ACME, then the resulting logonname in our example would be `road.runner@acme.ch`.
+This name would be in addition to the already generated `road.runner@acme.zitadel.ch`.
+The user can now use either logonname to authenticate with your application.
 
 ## Domain verification and primary domain
 
-Once you have successfully registered your organization, ZITADEL will automatically generate a domain name for your organization (eg, acme.zitadel.ch). Users that you create within your organization will be suffixed with this domain name.
+After you successfully register your organization, ZITADEL automatically generates a domain name for your organization (eg, acme.zitadel.ch).
+Users that you create within your organization will be suffixed with this domain name.
+When you create users with your organization, their logonnames will have this suffix.
 
-You can improve the user experience, by suffixing users with a domain name that is in your control. For that you can prove the ownership of your domain, by DNS or HTTP challenge.
+To aid user experience, suffix users with a domain name that is in your control.
+You can prove the ownership of your domain by DNS or HTTP challenge.
 
-An organization can have multiple domain names, but only one domain can be primary. The primary domain defines which login name ZITADEL displays to the user, and what information gets asserted in access_tokens (`preferred_username`).
+An organization can have multiple domain names, but only one domain can be primary.
+The primary domain defines which login name ZITADEL displays to the user, and what information gets asserted in `access_tokens` (`preferred_username`).
 
-Please note that domain verification also removes the logonname from all users, who might have used this combination in the global organization (ie. users not belonging to a specific organization). Relating to our example with acme.ch: If a user ‘coyote’ exists in the global organization with the logonname coyote@acme.ch, then after verification of acme.ch, this logonname will be replaced with `coyote@{randomvalue.tld}`. ZITADEL will notify users affected by this change.
+Please note that domain verification also removes the logonname from all users, who might have used this combination in the global organization (ie. users not belonging to a specific organization).
+In the example with `acme.ch`: If a user ‘coyote’ exists in the global organization with the logonname `coyote@acme.ch`, after `acme.ch` is verified this logonname will be replaced with `coyote@{randomvalue.tld}`.
+ZITADEL will notify users affected by this change.
 
 ## Exercise - Verify your domain name
 
-1. Browse to your organization
-2. Click **Add Domain**
-3. To start the domain verification click the domain name and a dialog will appear, where you can choose between DNS or HTTP challenge methods.
-4. For example, create a TXT record with your DNS provider for the used domain and click verify. ZITADEL will then proceed an check your DNS.
+1. Browse to your organization.
+2. Click **Add Domain**.
+3. To start the domain verification, click the domain name. A dialog appears, where you can choose between DNS or HTTP challenge methods.
+4. As an example, create a TXT record with your DNS provider for the used domain. Select **verify**.
+   ZITADEL will then check your DNS.
 5. When the verification is successful you have the option to activate the domain by clicking **Set as primary**
 
 ![Verify Domain](/img/console_verify_domain.gif)
@@ -93,10 +108,10 @@ Please note that domain verification also removes the logonname from all users, 
 
 ## Summary
 
-* Create your organization and a new user by visiting zitadel.ch
-* Organizations are the top-most vessel for your IAM objects, such as users or projects
-* Verify your domain in the Console to improve user experience; remember to not delete the verification code to allow recheck of ownership
-* You can delegate certain aspects of your IAM to other organizations for self-service
+* Create your organization and a new user by visiting zitadel.ch.
+* Organizations are the top-most vessel for your IAM objects, such as users or projects.
+* Verify your domain in the Console to improve user experience; remember to store the verification code to allow recheck of ownership.
+* You can delegate certain aspects of your IAM to other organizations for self-service.
 
 Where to go from here:
 

--- a/docs/docs/guides/basics/organizations.mdx
+++ b/docs/docs/guides/basics/organizations.mdx
@@ -3,11 +3,29 @@ title: Organizations
 ---
 
 
-|                   |                                                                                                                                                 |
-|-------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
-| Description       | Learn about ZITADEL's Organization-centered structure. See how to create your organization and verify a domain to use with that new organization. |
-| Learning Outcomes | In this module you will: <ul><li>Learn about organizations</li><li>Create a new organization</li><li>Verify your domain name </li></ul>         |
-| Prerequisites     | None                                                                                                                                            |
+<table class="table-wrapper">
+    <tr>
+        <td>Description</td>
+        <td>Learn about ZITADEL's Organization-centered structure. See how to create your organization and verify a domain to use with that new organization.</td>
+    </tr>
+    <tr>
+        <td>Learning Outcomes</td>
+        <td>
+            In this module you will:
+            <ul>
+              <li>Learn about organizations</li>
+              <li>Create a new organization</li>
+              <li>Verify your domain name</li>
+            </ul>
+        </td>
+    </tr>
+     <tr>
+        <td>Prerequisites</td>
+        <td>
+            None
+        </td>
+    </tr>
+</table>
 
 ## What is an organization?
 
@@ -119,6 +137,6 @@ ZITADEL will notify users affected by this change.
 Where to go from here:
 
 * Create a project
-* Setup Passwordless MFA
-* Manage ZITADEL Roles
+* Setup passwordless *MFA*
+* Manage ZITADEL roles
 * Grant roles to other organizations or users

--- a/docs/docs/guides/basics/organizations.mdx
+++ b/docs/docs/guides/basics/organizations.mdx
@@ -54,8 +54,9 @@ After you successfully register your organization, ZITADEL automatically generat
 Users that you create within your organization will be suffixed with this domain name.
 When you create users with your organization, their logonnames will have this suffix.
 
-To aid user experience, suffix users with a domain name that is in your control.
-You can prove the ownership of your domain by DNS or HTTP challenge.
+It's a good idea to use a domain name that you own for your loggonname suffix.
+This lets your users log in with their own company domain, improving user experience.
+You can prove the ownership of your domain by DNS or HTTP challenge ([Lets Encrypt has documentation about the different "challenge" types](https://letsencrypt.org/docs/challenge-types/)).
 
 An organization can have multiple domain names, but only one domain can be primary.
 The primary domain defines which login name ZITADEL displays to the user, and what information gets asserted in `access_tokens` (`preferred_username`).

--- a/docs/docs/guides/basics/organizations.mdx
+++ b/docs/docs/guides/basics/organizations.mdx
@@ -21,7 +21,7 @@ Afterwards, you can learn more in several other documentation modules, which det
 
 ## Exercise - Create a new organization
 
-To register your organization and create a user for ZITADEL, visit zitadel.ch or go directly <https://accounts.zitadel.ch/register/org> and fill in the required information.
+To register your organization and create a user for ZITADEL, visit zitadel.ch or go directly to <https://accounts.zitadel.ch/register/org> and fill in the required information.
 
 ![Register new Organization](/img/console_org_register.png)
 
@@ -41,7 +41,7 @@ These usernames include both humans and services.
 
 For example, the username `road.runner` can exist only once and only for one user in an organization called ACME.
 ZITADEL will automatically generate a *loginname* for each user, in the structure `{username}@{domainname}.{zitadeldomain}`.
-In this example, the *loginname*` would be `road.runner@acme.zitadel.ch`.
+In this example, the *loginname* would be `road.runner@acme.zitadel.ch`.
 
 When you verify your domain name, ZITADEL generates additional loginnames for each user with the verified domain.
 If ACME owned the domain acme.ch and verified this domain for the organization ACME, then the resulting loginname in our example would be `road.runner@acme.ch`.
@@ -60,7 +60,7 @@ You can prove the ownership of your domain by DNS or HTTP challenge ([Lets Encry
 An organization can have multiple domain names, but only one domain can be primary.
 The primary domain defines which loginname ZITADEL displays to the user, and what information gets asserted in `access_tokens` (`preferred_username`).
 
-Note that domain verification also removes the loginname from all users, some of whom might have used this combination in the global organization
+Note that for users, who might already have colliding loginnames in the global organization, these loginnames' domains are replaced by a random value on domain verification.
 (i.e. users who do not belong to a specific organization).
 In the example with `acme.ch`, if a user ‘coyote’ exists in the global organization with the loginname `coyote@acme.ch`,
 after ZITADEL verifies `acme.ch`, it will replace this loginname with `coyote@{randomvalue.tld}`.

--- a/docs/docs/guides/basics/organizations.mdx
+++ b/docs/docs/guides/basics/organizations.mdx
@@ -113,7 +113,7 @@ ZITADEL will notify users affected by this change.
 
 * Create your organization and a new user by visiting zitadel.ch.
 * Organizations are the top-most vessel for your IAM objects, such as users or projects.
-* Verify your domain in the Console to improve user experience; remember to store the verification code to allow recheck of ownership.
+* Verify your domain in the console to improve user experience; remember to store the verification code to allow recheck of ownership.
 * You can delegate certain aspects of your IAM to other organizations for self-service.
 
 Where to go from here:

--- a/docs/docs/guides/basics/organizations.mdx
+++ b/docs/docs/guides/basics/organizations.mdx
@@ -36,33 +36,34 @@ To register your organization and create a user for ZITADEL, visit zitadel.ch or
 
 ## How ZITADEL handles usernames
 
-As we mentioned before, each organization has its own pool of usernames.
+As mentioned, each organization has its own pool of usernames.
 These usernames include both humans and services.
 
-For example the username `road.runner` can only exist once and only for one user in an organization called ACME.
-ZITADEL will automatically generate a *logonname* for each  consisting of `{username}@{domainname}.{zitadeldomain}`.
-In this example, the *loggonname*` would be `road.runner@acme.zitadel.ch`.
+For example, the username `road.runner` can exist only once and only for one user in an organization called ACME.
+ZITADEL will automatically generate a *loginname* for each user, in the structure `{username}@{domainname}.{zitadeldomain}`.
+In this example, the *loginname*` would be `road.runner@acme.zitadel.ch`.
 
-When you verify your domain name, ZITADEL generates additional logonnames for each user with the verified domain.
-If ACME owned the domain acme.ch and verified this domain for the organization ACME, then the resulting logonname in our example would be `road.runner@acme.ch`.
+When you verify your domain name, ZITADEL generates additional loginnames for each user with the verified domain.
+If ACME owned the domain acme.ch and verified this domain for the organization ACME, then the resulting loginname in our example would be `road.runner@acme.ch`.
 This name would be in addition to the already generated `road.runner@acme.zitadel.ch`.
-The user can now use either logonname to authenticate with your application.
+The user can now use either loginname to authenticate with your application.
 
 ## Domain verification and primary domain
 
 After you successfully register your organization, ZITADEL automatically generates a domain name for your organization (eg, acme.zitadel.ch).
-Users that you create within your organization will be suffixed with this domain name.
-When you create users with your organization, their logonnames will have this suffix.
+When you create users with your organization, their loginnames will have this suffix.
 
-It's a good idea to use a domain name that you own for your loggonname suffix.
+It's a good idea to use a domain name that you own for your loginname suffix.
 This lets your users log in with their own company domain, improving user experience.
 You can prove the ownership of your domain by DNS or HTTP challenge ([Lets Encrypt has documentation about the different "challenge" types](https://letsencrypt.org/docs/challenge-types/)).
 
 An organization can have multiple domain names, but only one domain can be primary.
-The primary domain defines which login name ZITADEL displays to the user, and what information gets asserted in `access_tokens` (`preferred_username`).
+The primary domain defines which loginname ZITADEL displays to the user, and what information gets asserted in `access_tokens` (`preferred_username`).
 
-Please note that domain verification also removes the logonname from all users, who might have used this combination in the global organization (ie. users not belonging to a specific organization).
-In the example with `acme.ch`: If a user ‘coyote’ exists in the global organization with the logonname `coyote@acme.ch`, after `acme.ch` is verified this logonname will be replaced with `coyote@{randomvalue.tld}`.
+Note that domain verification also removes the loginname from all users, some of whom might have used this combination in the global organization
+(i.e. users who do not belong to a specific organization).
+In the example with `acme.ch`, if a user ‘coyote’ exists in the global organization with the loginname `coyote@acme.ch`,
+after ZITADEL verifies `acme.ch`, it will replace this loginname with `coyote@{randomvalue.tld}`.
 ZITADEL will notify users affected by this change.
 
 ## Exercise - Verify your domain name
@@ -71,12 +72,13 @@ ZITADEL will notify users affected by this change.
 2. Click **Add Domain**.
 3. To start the domain verification, click the domain name. A dialog appears, where you can choose between DNS or HTTP challenge methods.
 4. As an example, create a TXT record with your DNS provider for the used domain. Select **verify**.
-   ZITADEL will then check your DNS.
-5. When the verification is successful you have the option to activate the domain by clicking **Set as primary**
+   ZITADEL then checks your DNS.
+5. After successful verification, you can activate the domain by clicking **Set as primary**
+
+> **_Note:_** Do not delete the verification code, as ZITADEL will re-check the ownership of your domain from time to time
 
 ![Verify Domain](/img/console_verify_domain.gif)
 
-> **_Please note:_** Do not delete the verification code, as ZITADEL will re-check the ownership of your domain from time to time
 
 ## Knowledge Check
 

--- a/docs/docs/guides/basics/projects.md
+++ b/docs/docs/guides/basics/projects.md
@@ -15,17 +15,19 @@ import ProjectDescription from '../../concepts/structure/_project_description.md
 
 <ProjectDescription name="ProjectDescription" />
 
-The goal of this module is to give you an overview, but not dive too deep into details around managing access rights and delegating management of roles to third parties. So let’s create a straightforward example project first.
+The goal of this module is to give you an overview of managing access rights and delegating role management to third parties, without diving to deeply into the details.
+So let’s create a straightforward example project first.
 
 ## Exercise - Create a simple project
 
-Visit <https://console.zitadel.ch/projects> or select “Projects” within your organization, then click the button to create a new project.
+1. Visit <https://console.zitadel.ch/projects>, or select “Projects” within your organization.
+2. Select the button to create a new project.
 
 ![Empty Project](/img/console_projects_empty.png)
 
-Enter the name “ My first project” and continue.
+3. Enter the name `My first project` and continue.
 
-Let’s make this more interesting and add some basic roles and authorizations to your project and then confirm the scope of the roles and authorizations.
+Let’s make this more interesting and add some basic roles and authorizations to your project, then confirm the scope of the roles and authorizations.
 
 Jump to the section ROLES and create two new roles with the following values
 
@@ -41,7 +43,11 @@ and
 
 ![Add New Roles](/img/console_projects_add_new_roles.gif)
 
-Now, you can add roles to your own user, or you can create a new user. To create a new user, go to Users and click “New”. Enter the required contact details and save by clicking “Create”.
+Now, you can add roles to your own user, or you can create a new user.
+To create a new user:
+
+1. Go to Users and select **New**.
+2. Enter the required contact details and select **Create**.
 
 ![Create new user](/img/console_users_create_new_user.gif)
 
@@ -49,7 +55,11 @@ To grant users certain roles, you need to create authorizations. Go back to the 
 
 ![Verify your authorization](/img/console_projects_create_authorization.gif)
 
-You can verify the role grant on the user. Select Users from the navigation menu and click on the user Coyote. Scroll down to the section AUTHORIZATION, there you should be able to verify that the user has the role ‘reader’ for your project ‘My first project’.
+You can verify the role granted to the user.
+
+1. Select **Users** from the navigation menu.
+2. Select the user `Coyote`.
+3. Scroll down to the section AUTHORIZATION. There you should be able to verify that the user has the role `reader` for your project `My first project`.
 
 ![Organization grant](/img/console_projects_authorization_created.png)
 
@@ -63,8 +73,9 @@ import GrantedProjectDescription from '../../concepts/structure/_granted_project
 
 ## Exercise - Grant a project
 
-1. Visit the project that you have created before, then in the section GRANTED ORGANIZATIONS click New.
-2. Enter the domain ‘acme.caos.ch’, search the organization and continue to the next step.
+1. Visit the project that you created before. In the section GRANTED ORGANIZATIONS, select 
+**New**.
+2. Enter the domain ‘acme.caos.ch’. Search the organization and continue to the next step.
 3. Select some roles you would like to grant to the organization ACME and confirm.
 4. You should now see ACME-CAOS in the section GRANTED ORGANIZATIONS
 
@@ -75,10 +86,10 @@ import GrantedProjectDescription from '../../concepts/structure/_granted_project
 * You can setup multiple projects within an organization to manage scope
     - [ ] yes
     - [ ] no
-* Authorizations are define more detailed access rights within your application
+* Authorizations define more detailed access rights within your application
     - [ ] yes
     - [ ] no
-* Your projects as well as projects granted to your organization are visible within the Tab Projects of your organization
+* Your projects, as well as projects granted to your organization, are visible within the Tab Projects of your organization
     - [ ] yes
     - [ ] no
 
@@ -101,7 +112,7 @@ import GrantedProjectDescription from '../../concepts/structure/_granted_project
 
 ## Summary (2)
 
-* Manage scope of roles, authorizations and applications with projects
+* Use projects to manage the scope of roles, authorizations and applications
 * Create and assign roles to users of your organization within your project
 * Use project grants to enable other organizations to self-manage access rights (roles) to your applications
 

--- a/docs/docs/guides/basics/projects.md
+++ b/docs/docs/guides/basics/projects.md
@@ -5,7 +5,7 @@ title: Projects
 
 |                   |                                                                                                                                                                                                                          |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Description       | Learn the basics about applications, roles and authorizations, and how projects allow you to group these together.                                                                                                       |
+| Description       | Learn the basics about applications, roles and authorizations, then learn how projects allow you to group these together.                                                                                                       |
 | Learning Outcomes | In this module you will: <ul><li>Learn about projects and granted projects</li><li>Create a new project</li><li>Creating simple roles and authorizations</li><li>Create an organization grant for your project</li></ul> |
 | Prerequisites     | <ul><li>ZITADEL organizations</li><li>Role Based Access Management (RBAC)</li></ul>                                                                                                                                      |
 
@@ -15,21 +15,23 @@ import ProjectDescription from '../../concepts/structure/_project_description.md
 
 <ProjectDescription name="ProjectDescription" />
 
-The goal of this module is to give you an overview of managing access rights and delegating role management to third parties, without diving too deeply into the details.
-So let’s create a straightforward example project first.
+The goal of this module is to give you an overview of how to manage access rights and delegate role management to third parties.
+This module tries not to dive too deeply into the details.
+
+So, let’s create a straightforward example project.
 
 ## Exercise - Create a simple project
 
-1. Visit <https://console.zitadel.ch/projects>, or select “Projects” within your organization.
-2. Select the button to create a new project.
+1. Visit <https://console.zitadel.ch/projects>, or select **Projects** within your organization.
+2. Select **+ Create new project**.
 
 ![Empty Project](/img/console_projects_empty.png)
 
 3. Enter the name `My first project` and continue.
 
-Let’s make this more interesting and add some basic roles and authorizations to your project, then confirm the scope of the roles and authorizations.
+Let’s make this more interesting by adding some basic roles and authorizations to your project, then confirm the scope of the roles and authorizations.
 
-Jump to the section ROLES and create two new roles with the following values
+4. Jump to the section **ROLES**. Create two new roles with the following values
 
 * Key: reader
 * Display Name: Reader
@@ -46,24 +48,26 @@ and
 Now, you can add roles to your own user, or you can create a new user.
 To create a new user:
 
-1. Go to Users and select **New**.
+1. Go to **Users** and select **New**.
 2. Enter the required contact details and select **Create**.
 
 ![Create new user](/img/console_users_create_new_user.gif)
 
-To grant users certain roles, you need to create authorizations. Go back to the project, and jump to the section AUTHORIZATIONS.
+To grant users certain roles, you need to create authorizations.
+Go back to the project, and jump to the section **AUTHORIZATIONS**.
 
 ![Verify your authorization](/img/console_projects_create_authorization.gif)
 
-You can verify the role granted to the user.
+To verify the role granted to the user:
 
 1. Select **Users** from the navigation menu.
 2. Select the user `Coyote`.
-3. Scroll down to the section AUTHORIZATION. There you should be able to verify that the user has the role `reader` for your project `My first project`.
+3. Scroll down to the section **AUTHORIZATION**. There you should be able to verify that the user has the role `reader` for your project `My first project`.
 
 ![Organization grant](/img/console_projects_authorization_created.png)
 
-Now create another project (eg. “My second project”) and verify that there are no roles or authorizations on your second project.
+4. Now create another project (eg. “My second project”).
+5. Verify that there are no roles or authorizations on your second project.
 
 ## What is a granted project?
 
@@ -75,7 +79,7 @@ import GrantedProjectDescription from '../../concepts/structure/_granted_project
 
 1. Visit the project that you created before. In the section GRANTED ORGANIZATIONS, select 
 **New**.
-2. Enter the domain ‘acme.caos.ch’. Search the organization and continue to the next step.
+2. Enter the domain `acme.caos.ch`. Search the organization and continue to the next step.
 3. Select some roles that you would like to grant to the organization ACME. Confirm the change.
 4. You should now see ACME-CAOS in the section GRANTED ORGANIZATIONS
 
@@ -83,13 +87,13 @@ import GrantedProjectDescription from '../../concepts/structure/_granted_project
 
 ## Knowledge Check (2)
 
-* You can setup multiple projects within an organization to manage scope
+* You can set up multiple projects within an organization to manage scope.
     - [ ] yes
     - [ ] no
-* Authorizations define more detailed access rights within your application
+* Authorizations define more detailed access rights within your application.
     - [ ] yes
     - [ ] no
-* Your projects, as well as projects granted to your organization, are visible within the Tab Projects of your organization
+* Your projects, as well as projects granted to your organization, are visible within the Tab Projects of your organization.
     - [ ] yes
     - [ ] no
 

--- a/docs/docs/guides/basics/projects.md
+++ b/docs/docs/guides/basics/projects.md
@@ -23,7 +23,7 @@ So, let’s create a straightforward example project.
 ## Exercise - Create a simple project
 
 1. Visit <https://console.zitadel.ch/projects>, or select **Projects** within your organization.
-2. Select **+ Create new project**.
+2. Select **+ Create New Project**.
 
 ![Empty Project](/img/console_projects_empty.png)
 

--- a/docs/docs/guides/basics/projects.md
+++ b/docs/docs/guides/basics/projects.md
@@ -15,7 +15,7 @@ import ProjectDescription from '../../concepts/structure/_project_description.md
 
 <ProjectDescription name="ProjectDescription" />
 
-The goal of this module is to give you an overview of managing access rights and delegating role management to third parties, without diving to deeply into the details.
+The goal of this module is to give you an overview of managing access rights and delegating role management to third parties, without diving too deeply into the details.
 So let’s create a straightforward example project first.
 
 ## Exercise - Create a simple project

--- a/docs/docs/guides/basics/projects.md
+++ b/docs/docs/guides/basics/projects.md
@@ -3,11 +3,34 @@ title: Projects
 
 ---
 
-|                   |                                                                                                                                                                                                                          |
-| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Description       | Learn the basics about applications, roles and authorizations, then learn how projects allow you to group these together.                                                                                                       |
-| Learning Outcomes | In this module you will: <ul><li>Learn about projects and granted projects</li><li>Create a new project</li><li>Creating simple roles and authorizations</li><li>Create an organization grant for your project</li></ul> |
-| Prerequisites     | <ul><li>ZITADEL organizations</li><li>Role Based Access Management (RBAC)</li></ul>                                                                                                                                      |
+
+<table class="table-wrapper">
+    <tr>
+        <td>Description</td>
+        <td>Learn the basics about applications, roles and authorizations, then learn how projects allow you to group these.</td>
+    </tr>
+    <tr>
+        <td>Learning Outcomes</td>
+        <td>
+            In this module you will:
+            <ul>
+              <li>Learn about projects and granted projects</li>
+              <li>Create a new project</li>
+              <li>Create a simple role and an authorization</li>
+              <li>Create an organization grant for your project</li>
+            </ul>
+        </td>
+    </tr>
+     <tr>
+        <td>Prerequisites</td>
+        <td>
+            <ul>
+                <li>ZITADEL organizations</li>
+                <li>Role Based Access Management (RBAC)</li>
+            </ul>
+        </td>
+    </tr>
+</table>
 
 ## What is a project?
 

--- a/docs/docs/guides/basics/projects.md
+++ b/docs/docs/guides/basics/projects.md
@@ -31,42 +31,38 @@ So, let’s create a straightforward example project.
 
 Let’s make this more interesting by adding some basic roles and authorizations to your project, then confirm the scope of the roles and authorizations.
 
-4. Jump to the section **ROLES**. Create two new roles with the following values
+4. Jump to the section **ROLES**. Create a new roles with the following values
 
 * Key: reader
 * Display Name: Reader
 * Group: user
 
-and
-
-* Key: editor
-* Display Name: Editor
-* Group: user
-
 ![Add New Roles](/img/console_projects_add_new_roles.gif)
 
-Now, you can add roles to your own user, or you can create a new user.
-To create a new user:
+Now, create a new user `coyote`.
 
 1. Go to **Users** and select **New**.
-2. Enter the required contact details and select **Create**.
+2. Use some random values for the required fields, then select **Create**.
 
 ![Create new user](/img/console_users_create_new_user.gif)
 
+Now, grant `coyote` the role `reader`
 To grant users certain roles, you need to create authorizations.
-Go back to the project, and jump to the section **AUTHORIZATIONS**.
+1. Go back to the project, and jump to the section **AUTHORIZATIONS**.
+2. Search and select the user `coyote`, then select **CONTINUE**.
+3. Check the role `reader`, then select `Save`.
 
 ![Verify your authorization](/img/console_projects_create_authorization.gif)
 
-To verify the role granted to the user:
+Now, verify that the user `coyote` has the role `reader`:
 
 1. Select **Users** from the navigation menu.
-2. Select the user `Coyote`.
-3. Scroll down to the section **AUTHORIZATION**. There you should be able to verify that the user has the role `reader` for your project `My first project`.
+2. Select the user `coyote`.
+3. Scroll down to the section **AUTHORIZATION**. You see, `coyote` has the role `reader` in the project `My first project`.
 
 ![Organization grant](/img/console_projects_authorization_created.png)
 
-4. Now create another project (eg. “My second project”).
+4. Now create another project (eg. `My second project`).
 5. Verify that there are no roles or authorizations on your second project.
 
 ## What is a granted project?
@@ -77,11 +73,11 @@ import GrantedProjectDescription from '../../concepts/structure/_granted_project
 
 ## Exercise - Grant a project
 
-1. Visit the project that you created before. In the section GRANTED ORGANIZATIONS, select 
+1. Visit the project that you created before. In the section **GRANTED ORGANIZATIONS**, select 
 **New**.
 2. Enter the domain `acme.caos.ch`. Search the organization and continue to the next step.
-3. Select some roles that you would like to grant to the organization ACME. Confirm the change.
-4. You should now see ACME-CAOS in the section GRANTED ORGANIZATIONS
+3. Select some roles that you would like to grant to the organization `ACME`. Confirm the change.
+4. You should now see `ACME` in the section **GRANTED ORGANIZATIONS**
 
 ![Grant a project](/img/projects_create_org_grant_caos2acme.gif)
 

--- a/docs/docs/guides/basics/projects.md
+++ b/docs/docs/guides/basics/projects.md
@@ -76,7 +76,7 @@ import GrantedProjectDescription from '../../concepts/structure/_granted_project
 1. Visit the project that you created before. In the section GRANTED ORGANIZATIONS, select 
 **New**.
 2. Enter the domain ‘acme.caos.ch’. Search the organization and continue to the next step.
-3. Select some roles you would like to grant to the organization ACME and confirm.
+3. Select some roles that you would like to grant to the organization ACME. Confirm the change.
 4. You should now see ACME-CAOS in the section GRANTED ORGANIZATIONS
 
 ![Grant a project](/img/projects_create_org_grant_caos2acme.gif)

--- a/docs/docs/guides/customization/branding.md
+++ b/docs/docs/guides/customization/branding.md
@@ -2,42 +2,54 @@
 title: Brand Customization
 ---
 
-ZITADEL offers various customization options for your projects brand design. 
-Head over to the Private Labeling Policy on your Organization Page.
+ZITADEL lets you customize the interface for your project's brand design. 
+To customize, head to your Organization page, then to **Private Labeling Policy**.
 
 ## How it works
-You are able to customize the light and a dark mode separately.
-All your changes will be shown in the preview window on the right side.
-As soon as you are happy with your configuration click the "Apply configuration" button.
-After this your settings will trigger in your system. The login and the emails will be sent with your branding.
+You can customize light and dark modes separately.
+All your changes are shown in the preview window on the right side.
+As soon as you are happy with your configuration, select **Apply configuration**.
+After this your settings will trigger in your system.
+The login and the emails will be sent with your branding.
 
 ## Settings
 
 ![Private Labeling](/img/console_private_labeling.png)
 
 ### Logo
-Upload your logo for the chosen theme, as soon as it is uploaded the preview on the right side of the screen should show it.
+Upload your logo for the chosen theme.
+As soon as it is uploaded, the preview on the right side of the screen shows it.
 
 ### Colors
 In the next part you can configure your colors. 
-Background colour is self-explanatory, the primary color will be used for buttons, links and some highlights. 
-The warn color is used for all the error messages and warnings and the font colour for texts. 
+* Background color is the background.
+* The primary color is used for buttons, links and some highlights. 
+* The warn color is used for all the error messages and warnings.
+* The font color is for texts. 
 
 ### Font
-Last step to apply to your branding is the font upload. 
-The best way is to upload a ttf file after a successful upload you will see it in the font part, but not in the preview.
+
+The last step is to upload your font. 
+The best way is to upload a TTF file.
+
+After a successful upload, you will see it in the font part, but not in the preview.
 
 ### Advanced Settings
-In the advanced behavior you can choose if the loginname suffix (domain e.g road.runner@acme.caos.ch) should be shown in the loginname screen or not and if the “ZITADEL watermark” should be hidden.
+
+In the advanced behavior, you can choose whether to show the loginname suffix (domain e.g road.runner@acme.caos.ch) in the loginname screen.
+You can also configure whether to hide the ZITADEL watermark.
 
 ## Trigger the private labeling for the login
-If you like to trigger your settings for your applications you have different possibilities.
 
-### 1. Primary Domain Scope
+If you want to trigger your settings for your applications, you have different possibilities.
+
+### A. Primary Domain Scope
 Send a [primary domain scope](https://docs.zitadel.ch/docs/apis/openidoauth/scopes#reserved-scopes) with your [authorization request](https://docs.zitadel.ch/docs/guides/authentication/login-users/#auth-request) to trigger your organization.
-The primary domain scope will restrict the login to your organization, so only users of your own organization will be able to login.
+The primary domain scope will restrict the login to your organization.
+Only users of your own organization will be able to login.
 
-See the following link as an example. Users will be able to register and login to the organization that verified the @caos.ch domain only.
+See the following link as an example.
+Users can register and log in only to the organization that verified the @caos.ch domain.
 ```
 https://accounts.zitadel.ch/oauth/v2/authorize?client_id=69234247558357051%40zitadel&scope=openid%20profile%20urn%3Azitadel%3Aiam%3Aorg%3Adomain%3Aprimary%3Acaos.ch&redirect_uri=https%3A%2F%2Fconsole.zitadel.ch%2Fauth%2Fcallback&state=testd&response_type=code&nonce=test&code_challenge=UY30LKMy4bZFwF7Oyk6BpJemzVblLRf0qmFT8rskUW0
 ```
@@ -50,15 +62,17 @@ Make sure to replace the domain `caos.ch` with your own domain to trigger the co
 
 :::caution
 
-This example uses the ZITADEL Cloud Application for demonstration. You need to create your own auth request with your applications parameters. Please see the docs to construct an [Auth Request](https://docs.zitadel.ch/docs/guides/authentication/login-users/#auth-request).
+This example uses the ZITADEL Cloud Application for demonstration.
+You need to create your own auth request with your application parameters.
+Refer to the docs [to construct an Auth Request](https://docs.zitadel.ch/docs/guides/authentication/login-users/#auth-request).
 
 :::
 
 
 
-### 2. Setting on your Project
+### B. Setting on your Project
 Set the private labeling setting on your project to define which branding should trigger.
 
 ## Reset to default
-If you don't like your customization anymore click the "reset policy" button.
+If you don't like your customization anymore, select the **reset policy** button.
 All your settings will be removed and the default settings of the system will trigger.

--- a/docs/docs/guides/customization/texts.md
+++ b/docs/docs/guides/customization/texts.md
@@ -2,37 +2,40 @@
 title: Customized Texts
 ---
 
-You are able to customize the texts used from ZITADEL.
+You can customize the texts sent by ZITADEL.
 
 ## Message Texts
-Sometimes the users will get an email or phone message from ZITADEL (e.g Password Reset Request).
-ZITADEL already has some good standard texts, but maybe you would like to customize it for your organization.
+Sometimes users get an email or phone message from ZITADEL (e.g Password Reset Request).
+ZITADEL already has some good standard texts, but you might like to customize them for your organization.
+To do that, follow these steps:
 
-Go to the message text policy on your organization and you will find the different kinds of messages that are sent from ZITADEL. 
-Choose the template and the language you like to edit. 
-You can now change all the texts from a message. 
-As soon as you click into a input field you will see some attribute chips below the field. 
-These are the parameters you can include on this specific message.
+1. Go to the message text policy in your organization. You will find the different kinds of messages ZITADEL sends. 
+1. Choose the template and the language you like to edit. 
+1. Change all the texts as you wish.
+  As soon as you select an input field, you will see some attribute chips below the field. 
+  These are the parameters you can include for this specific message.
 
 ![Message Texts](/img/console_message_texts.png)
 
 ## Login Texts
 
-Like the message texts you are also able to change the texts on the login interface. 
-First choose the screen and the language you like to edit. 
-You will see the default texts in the input field and you can overwrite them by typing into the box.
+Like the message texts, you can also change the texts on the login interface. 
+
+1. Choose the screen and the language you would like to edit. 
+   You will see the default texts in the input field.
+1. Overwrite the defaults by typing into the box.
 
 ![Message Texts](/img/console_login_texts.png)
 
 ## Reset to default
 
-If you don't like your customization anymore click the "reset policy" button.
+If you don't like your customization anymore, select the **reset policy** button.
 All your settings will be removed and the default settings of the system will trigger.
 
 ## Internationalization
 
-ZITADELs support for languages will be extended with time. 
-If you need support for a specific language we highly recommend you to write translation files for the missing language.
+ZITADEL's support for languages will be extended with time. 
+If you need support for a specific language, we highly recommend you to write translation files for the missing language.
 
 ZITADEL loads translations from three files:
 
@@ -41,5 +44,5 @@ ZITADEL loads translations from three files:
  - [Email Notifcation texts](https://github.com/caos/zitadel/tree/main/internal/notification/static/i18n)
  - [Common translations](https://github.com/caos/zitadel/tree/main/internal/static/i18n) for success or error toasts
 
- Make sure you set the locale as the name. Later on, language header will determine which file gets displayed.
+ Make sure you set the locale as the name. Later on, a language header will determine which file gets displayed.
 

--- a/docs/docs/guides/integrations/authenticated-mongodb-charts.md
+++ b/docs/docs/guides/integrations/authenticated-mongodb-charts.md
@@ -5,7 +5,7 @@ title: Authenticated MongoDB Charts
 If you want to embed authenticated MongoDB Charts in your web application, you can use ZITADEL as an authentication provider.
 This integration guide shows you how.
 
-## Setup ZITADEL Application
+## Setup your ZITADEL application
 
 Before you embed an authenticated chart in your application, you need to provide some information about your app in the ZITADEL Console.
 We recommend creating a new app to start from scratch.
@@ -24,7 +24,7 @@ Your application configuration should now look similar to this:
 
 ## Setup Custom JWT Provider for MongoDB Charts
 
-Configure ZITADEL as your _Custom JWT Provider_ following the [MongoDB docs](https://docs.mongodb.com/charts/configure-auth-providers/) .
+To configure ZITADEL as your _Custom JWT Provider_, follow the [MongoDB docs](https://docs.mongodb.com/charts/configure-auth-providers/) .
 
 Configure the following values:
 - Signing Algorithm: RS256
@@ -38,9 +38,10 @@ Your configuration should look similar to this:
 
 ## Embedding your Chart
 
-Now, embed a chart into your application. To do so, follow the corresponding [MongoDB docs](https://docs.mongodb.com/charts/saas/embed-chart-jwt-auth/).
+Now, embed a chart into your application.
+To do so, follow the corresponding [MongoDB docs](https://docs.mongodb.com/charts/saas/embed-chart-jwt-auth/).
 
-If you've done the [Angular Quickstart](../../quickstarts/login/angular.md), your code could look something like this:
+If you've done the [Angular Quickstart](../../quickstarts/login/angular.md), your code might look something like this:
 
 ```html
 <!-- chart.component.html -->
@@ -50,7 +51,7 @@ If you've done the [Angular Quickstart](../../quickstarts/login/angular.md), you
 ```css
 /* chart.component.css */
 div#chart {
-    height: 500px;    
+    height: 500px;
 }
 ```
 

--- a/docs/docs/guides/integrations/authenticated-mongodb-charts.md
+++ b/docs/docs/guides/integrations/authenticated-mongodb-charts.md
@@ -2,20 +2,21 @@
 title: Authenticated MongoDB Charts
 ---
 
-This integration guide shows how you can embed authenticated MongoDB Charts in your web application using ZITADEL as authentication provider.
+If you want to embed authenticated MongoDB Charts in your web application, you can use ZITADEL as an authentication provider.
+This integration guide shows you how.
 
 ## Setup ZITADEL Application
 
-Before you can embed an authenticated chart in your application, you have to do a few configuration steps in ZITADEL Console.
-You will need to provide some information about your app. We recommend creating a new app to start from scratch.
+Before you embed an authenticated chart in your application, you need to provide some information about your app in the ZITADEL Console.
+We recommend creating a new app to start from scratch.
 
 1. Navigate to your [Project](https://console.zitadel.ch/projects)
 1. Add a new application at the top of the page.
 1. Select Web application type and continue.
 1. Use [Authorization Code](../../apis/openidoauth/grant-types#authorization-code) in combination with [Proof Key for Code Exchange (PKCE)](../../apis/openidoauth/grant-types#proof-key-for-code-exchange).
-1. Skip the redirect settings and confirm the app creation
-1. Copy the client ID, you will need to tell MongoDB Charts about it.
-1. When you created the app, expand its _OIDC Configuration_ section, change the _Auth Token Type_ to _JWT_ and save the change.
+1. Skip the redirect settings. Confirm the app creation
+1. Copy the client ID. You will need to tell MongoDB Charts about it.
+1. Once you create the app, expand its **OIDC Configuration** section, change the **Auth Token Type** to _JWT_. Save the change.
 
 Your application configuration should now look similar to this:
 
@@ -37,7 +38,7 @@ Your configuration should look similar to this:
 
 ## Embedding your Chart
 
-Embed a chart into your application now, following the corresponding [MongoDB docs](https://docs.mongodb.com/charts/saas/embed-chart-jwt-auth/).
+Now, embed a chart into your application. To do so, follow the corresponding [MongoDB docs](https://docs.mongodb.com/charts/saas/embed-chart-jwt-auth/).
 
 If you've done the [Angular Quickstart](../../quickstarts/login/angular.md), your code could look something like this:
 

--- a/docs/docs/guides/integrations/authenticated-mongodb-charts.md
+++ b/docs/docs/guides/integrations/authenticated-mongodb-charts.md
@@ -7,7 +7,7 @@ This integration guide shows you how.
 
 ## Setup your ZITADEL application
 
-Before you embed an authenticated chart in your application, you need to provide some information about your app in the ZITADEL Console.
+Before you embed an authenticated chart in your application, you need to provide some information about your app in the ZITADEL console.
 We recommend creating a new app to start from scratch.
 
 1. Navigate to your [Project](https://console.zitadel.ch/projects)

--- a/docs/docs/guides/overview.mdx
+++ b/docs/docs/guides/overview.mdx
@@ -9,7 +9,7 @@ These guides cover everything you need to know about how to manage your data and
 You'll get step-by-step instructions, background info, and recommended practices.
 Some tasks and have a knowledge check at the end.
 
-You can either use our cloud-instance [zitadel.ch](https://zitadel.ch) or deploy a dedicated **ZITADEL** instance.
+You can either use our cloud-instance [zitadel.ch](https://zitadel.ch) or deploy a dedicated ZITADEL instance.
 To [get started](./basics/get-started), we recommend trying out our free tier first.
 
 Once you are familiar with using ZITADEL, you can decide how you want to continue using the app:

--- a/docs/docs/guides/overview.mdx
+++ b/docs/docs/guides/overview.mdx
@@ -5,17 +5,16 @@ title: Overview
 import { ListElement, ListWrapper, ICONTYPE } from "../../src/components/list";
 import Column from "../../src/components/column";
 
-These cover everything you need to know about how to manage your data and associate roles in ZITADEL.
-You get step-by-step instructions.
+These guides cover everything you need to know about how to manage your data and associate roles in ZITADEL.
+You'll get step-by-step instructions, background info, and recommended practices.
 Some tasks and have a knowledge check at the end.
 
 You can either use our cloud-instance [zitadel.ch](https://zitadel.ch) or deploy a dedicated **ZITADEL** instance.
-To get started, we recommend you to try out our free tier first.
-Jump directly to the [get started](./basics/get-started) docs.
+To [get started](./basics/get-started), we recommend trying out our free tier first.
 
-When you are familiar with the ZITADEL usage, you can choose how you want to use the app:
-* Stay on [zitadel.ch](./installation/shared-cloud),
-* Order your own [dedicated instance](./installation/shared-cloud) which is also available on premise,
+Once you are familiar with using ZITADEL, you can decide how you want to continue using the app:
+* Stay on [zitadel.ch](./installation/shared-cloud).
+* Order your own [dedicated instance](./installation/shared-cloud) (also available on premise).
 * Install ZITADEL on your own using [Custom Kubernetes Resources](./installation/crd), [GitOps](./installation/gitops) or [ORBOS](./installation/orbos).
 
 <Column>

--- a/docs/docs/guides/overview.mdx
+++ b/docs/docs/guides/overview.mdx
@@ -5,11 +5,18 @@ title: Overview
 import { ListElement, ListWrapper, ICONTYPE } from "../../src/components/list";
 import Column from "../../src/components/column";
 
-With our guides you will learn everything you need to know about specific topics. You get step-by-step instructions for certain tasks and have a knowledge check at the end.
+These cover everything you need to know about how to manage your data and associate roles in ZITADEL.
+You get step-by-step instructions.
+Some tasks and have a knowledge check at the end.
 
-You can either use our cloud-instance [zitadel.ch](https://zitadel.ch) or deploy a dedicated **ZITADEL** instance. To get started, we recommend you to try out our free tier first. Jump directly to the [get started](./basics/get-started) docs.
+You can either use our cloud-instance [zitadel.ch](https://zitadel.ch) or deploy a dedicated **ZITADEL** instance.
+To get started, we recommend you to try out our free tier first.
+Jump directly to the [get started](./basics/get-started) docs.
 
-When you are familiar with the ZITADEL usage, you can choose to stay on [zitadel.ch](./installation/shared-cloud), order your own [dedicated instance](./installation/shared-cloud) which is also availabe on premise, or install ZITADEL easily on your own using [Custom Kubernetes Resources](./installation/crd), [GitOps](./installation/gitops) or [ORBOS](./installation/orbos).
+When you are familiar with the ZITADEL usage, you can choose how you want to use the app:
+* Stay on [zitadel.ch](./installation/shared-cloud),
+* Order your own [dedicated instance](./installation/shared-cloud) which is also available on premise,
+* Install ZITADEL on your own using [Custom Kubernetes Resources](./installation/crd), [GitOps](./installation/gitops) or [ORBOS](./installation/orbos).
 
 <Column>
   <ListWrapper title="Get to know ZITADEL">

--- a/docs/docs/guides/solution-scenarios/b2b.mdx
+++ b/docs/docs/guides/solution-scenarios/b2b.mdx
@@ -9,7 +9,7 @@ This is different from typical [B2C](./b2c) cases, where the organization often 
 
 ## Business to Business
 
-This *multi-organization architecture* usually adds complexity to an Identity and Access Management System.
+This *multi-organization architecture* usually adds complexity to an identity and access management system.
 In ZITADEL, a B2B organization represents a business partner or a partner who typically has their own branding and different access settings, like an additional federated login for its users.
 
 B2B can be a simple scenario, e.g. where an organization shares only one of its projects with another organization.
@@ -73,7 +73,7 @@ Our sample organizations have these users:
 
 - Dimitri: a team leader who is employed by Pentagon, an Octagon department.
   Dimitri uses his Microsoft Account in combination with his one-time password to access the portal.
-  Pentagon therefore has set up Microsoft as Identity Provider.
+  Pentagon therefore has set up Microsoft as identity provider.
   Pentagon also requires its users to secure their accounts with additional factors.
 - Michael: a trainee of Pentagon using the portal only to access his workspace apps.
   Michael uses his Google Account in combination with his laptop's fingerprint.

--- a/docs/docs/guides/solution-scenarios/b2b.mdx
+++ b/docs/docs/guides/solution-scenarios/b2b.mdx
@@ -4,8 +4,8 @@ title: B2B
 
 import { B2B } from '../../../src/components/b2b';
 
-As opposed to [B2C](./b2c), where the organization often interacts with end users and other individuals,
-in _Business to business (B2B)_ scenarios, an organization interacts with other organizations.
+In _Business to business (B2B)_ scenarios, an organization interacts with other organizations.
+This is different from typical [B2C](./b2c) cases, where the organization often interacts with end users and other individuals.
 
 ## Business to Business
 
@@ -29,9 +29,10 @@ When describing multiple-organization scenarios, this topic sometimes also refer
 ### Portal Application
 
 Octagon has a *Portal application*, where its employees can access their account and list all applications they are allowed to use.
+
 Employees work for a department within Octagon, or for Octagon itself. 
 Some users supervise teams.
-These users have enhanced features, letting them onboard new employees and manage their roles and access.
+These users have enhanced permissions, letting them onboard new employees and manage their roles and access.
 Target groups of the application can be split into:
 - Employees: users who use the application as a starting point for their work.
 - Supervisors: users who use the application to manage users and their access of their department.
@@ -43,18 +44,19 @@ To define the Portal Application's needs, the application's builders need to con
 
 - Login and Access: Does a user have a preset organization to log in?
   Does the application show the default login page, or does each organization use its own branding?
-- Organizations: Does a user have access in multiple organizations?
+- Organizations: Does a user have access to multiple organizations?
   Is a user required to use a different federated login for those organizations?
 - Roles: Does the application need users to have specific roles assigned within their organizations?
   Which roles are needed to enable certain features of the application?
 
 ### Login
 
-You can decide whether a organization is preselected for the login, an
+You can decide whether a organization is preselected for the login, or redirected to a login screen.
 
-To send the user to a specific organization, define the organization in a custom scope (primary domain).
-To change the branding or the login options of the organization, head to the organization section in [Console](https://console.zitadel.ch/org). 
 To set the behavior of the login, go to your projects detail page.
+To send the user to a specific organization, define the organization in a custom scope (primary domain).
+
+To change the branding or the login options of the organization, head to the organization section in [Console](https://console.zitadel.ch/org). 
 You can choose the branding of the selected organization, the user resource owner, or the project's resource owner.
 
 ### Organizations
@@ -74,7 +76,7 @@ Our sample organization has these users:
   Octagon therefore has set up Microsoft as Identity Provider.
   Octagon also requires its users to secure their accounts with additional factors.
 - Michael: a trainee of Pentagon using the portal only to access his workspace apps.
-  Michael uses his Google Account in combination with his laptops fingerprint.
+  Michael uses his Google Account in combination with his laptop's fingerprint.
 - Bill: an employee of Octagon, working as Administrator of the Portal Application.
   Bill also uses a Microsoft Account in combination with a Security Key to secure his account.
 

--- a/docs/docs/guides/solution-scenarios/b2b.mdx
+++ b/docs/docs/guides/solution-scenarios/b2b.mdx
@@ -4,79 +4,111 @@ title: B2B
 
 import { B2B } from '../../../src/components/b2b';
 
+As opposed to [B2C](./b2c), where the organization often interacts with end users and other individuals,
+in _Business to business (B2B)_ scenarios, an organization interacts with other organizations.
+
 ## Business to Business
 
-B2B describes the situation where an organization interacts with other organizations.
-This **multiple organization architecture** usually adds some form of complexity to an Identity and Access Management System.
-In ZITADEL a B2B organization represents a business partner or partner who typically has its own branding and has different access settings like an additional federated login for its users.
+This *multi-organization architecture* usually adds complexity to an Identity and Access Management System.
+In ZITADEL, a B2B organization represents a business partner or a partner who typically has their own branding and different access settings, like an additional federated login for its users.
 
-B2B can be a simple scenario where an organization only shares one of its projects with another organization or have a more complex case where an organization is offering a portal application to all its partners with included (self)administration.
+B2B can be a simple scenario, e.g. where an organization shares only one of its projects with another organization.
+B2B can also be a more complex case, e.g. where an organization offers a portal application to all its partners with included (self)administration.
 
 <!-- This guide describes an application  -->
 ## Sample scenario
 
-Octagon is a fictitious company which is used throughout this guide to explain the details and key concepts of such a B2B scenario.
-Octagon tries to solve multiple tasks in the banking field. Its portfolio includes several applications for their employees, customers, and partners. Some of which are web-based, some of which are used by machine users only.
+To explain the details and key concepts of a B2B scenario, this topic uses a fictional company, Octagon, as an example.
+
+Octagon tries to solve multiple tasks in the banking field.
+Its portfolio includes several applications for their employees, customers, and partners.
+Some of these applications are web-based, used by only machine users.
+
+When describing multiple-organization scenarios, this topic sometimes also refers to a sub-organization of Octagon, Pentagon.
 
 ### Portal Application
 
-Octagon has a **Portal application** where its employees can access their account and list all applications they are allowed to use.
-Employees work for a department within Octagon or for Octagon itself. 
-Some of the users have enhanced features because they supervise certain teams. Those can onboard new employees and manage their roles and features.
+Octagon has a *Portal application*, where its employees can access their account and list all applications they are allowed to use.
+Employees work for a department within Octagon, or for Octagon itself. 
+Some users supervise teams.
+These users have enhanced features, letting them onboard new employees and manage their roles and access.
 Target groups of the application can be split into:
-- **Employees:** users who are using the application as a starting point for their work.
-- **Supervisors:** users who are mainly using the application to manage users and their access of their department.
-- **Administrators:** this users are able to grant additional organizations or departments and elect supervisors.
+- Employees: users who use the application as a starting point for their work.
+- Supervisors: users who use the application to manage users and their access of their department.
+- Administrators: users who can grant additional organizations or departments and elect supervisors.
 
 ### Planning considerations
 
-In order to define the need of the **Portal Application** some planning considerations about organizations have to be made:
+To define the Portal Application's needs, the application's builders need to consider how the organization is made:
 
-- **Login and Access:** Does a user have a preset organization to login? Does the application show the default login page or does each organization use its own branding?
-- **Organizations:** Does a user have access in multiple organizations? Is a user required to use a different federated login for those organizations?
-- **Roles** Does the application need users to have specific roles assigned within their organizations? Which roles are needed to enable certain features of the application?
+- Login and Access: Does a user have a preset organization to log in?
+  Does the application show the default login page, or does each organization use its own branding?
+- Organizations: Does a user have access in multiple organizations?
+  Is a user required to use a different federated login for those organizations?
+- Roles: Does the application need users to have specific roles assigned within their organizations?
+  Which roles are needed to enable certain features of the application?
 
 ### Login
 
-You can decide whether a organization is preselected for the login or if the user is redirected to the default login screen. You can send the user to a specific organization by defining the organization in a custom scope. (primary domain)
-Settings to the branding or the login options of the organization can be made from the organization section in [Console](https://console.zitadel.ch/org). 
-The behaviour of the login branding can be set in your projects detail page. You can choose the branding of the selected organization, the user resource owner, or the projects resource owner.
+You can decide whether a organization is preselected for the login, an
+
+To send the user to a specific organization, define the organization in a custom scope (primary domain).
+To change the branding or the login options of the organization, head to the organization section in [Console](https://console.zitadel.ch/org). 
+To set the behavior of the login, go to your projects detail page.
+You can choose the branding of the selected organization, the user resource owner, or the project's resource owner.
 
 ### Organizations
 
-Generally a user belongs to and is managed by one organization, however the user can receive authorizations from multiple other organizations (delegated authorizations). Anyways, a user should be able to use the same identity to switch between organizations.
-If this feature is not desired, a separate user for each organization should be created.
+Generally a user belongs to and is managed by one organization.
+However the user can receive authorizations from multiple other organizations (delegated authorizations).
+Anyway, a user should be able to use the same identity to switch between organizations.
+If you don't want this feature, create a separate user for each organization.
 
-Adding a user from a different organization to the audience of a project can be as easy as adding a new user authorization (user grant). A user grant combines a user from any organization with a project and 0-N roles.
+To add a user from a different organization to a project's audience, you can add a new user authorization (user grant).
+A user grant combines a user from any organization with a project and 0-N roles.
 
-In our sample scenario, we assume to have the following users:
+Our sample organization has these users:
 
-- **Dimitri:** a team leader who is employed by Pentagon, an Octagon department. Dimitri uses his Microsoft Account in combination with his one time password to access the portal. Pentagon therefore has set up Microsoft as Identity Provider. Pentagon also requires its users to secure their accounts with additional factors.
-- **Michael:** a trainee of Pentagon only using the portal to access his workspace apps. Michael uses his Google Account in combination with his laptops fingerprint.
-- **Bill:** is employed at Octagon as Administrator of the Portal Application. Bill also uses a Microsoft Account in combination with a Security Key to secure his account.
+- Dimitri: a team leader who is employed by Pentagon, an Octagon department.
+  Dimitri uses his Microsoft Account in combination with his one-time password to access the portal.
+  Octagon therefore has set up Microsoft as Identity Provider.
+  Octagon also requires its users to secure their accounts with additional factors.
+- Michael: a trainee of Pentagon using the portal only to access his workspace apps.
+  Michael uses his Google Account in combination with his laptops fingerprint.
+- Bill: an employee of Octagon, working as Administrator of the Portal Application.
+  Bill also uses a Microsoft Account in combination with a Security Key to secure his account.
 
-After having determined the constellation of the organizations and its users, all the necessary data (Portal project with roles and app, users, login requirements, identity providers, branding) should be set up in [Console](https://console.zitadel.ch/org).
-A B2B sample application for NextJS can be found in our [Example Repo](https://github.com/caos/zitadel-examples).
+After you understand the constellation of the organizations and its users, use the
+[Console](https://console.zitadel.ch/org) to set up all the necessary data (Portal project with roles and app, users, login requirements, identity providers, branding).
 
-To allow another organization to use a project, a project grant has to be created. Upon creation, roles for a grant can be limited to a subset of the total project roles.
+A sample B2B application for NextJS can be found in our [Example Repo](https://github.com/caos/zitadel-examples).
 
-In our scenario, Octagon creates a project grant for Pentagon. Pentagon is limited to use `writer` and `reader` role. The `admin` role is reserved for the Octagon organization itself.
+To allow another organization to use a project, create a project grant. Upon creation, you can limit roles for a grant to a subset of the total project roles.
+
+In our scenario, Octagon creates a project grant for Pentagon.
+Pentagon is limited to use the roles `writer` and `reader`.
+The `admin` role is reserved for the Octagon organization itself.
 
 <B2B></B2B>
 
 ### Roles
 
-In this scenario, Dimitri and Michael share the same organization Pentagon, where as Bill belongs to Octagon. Octagon is owner of the Portal project with its Web App, having Bill configured as user grant with `admin` role. Dimitri owns the `writer` role, whereas Michael only is `reader`.
+In this scenario, Dimitri and Michael both belong to the organization Pentagon.
+Bill belongs to Octagon.
+Octagon is owner of the Portal project with its Web App, where Bill is configured as user grant with `admin` role.
+Dimitri owns the `writer` role, whereas Michael is only a `reader`.
 
-> Note: Roles are meant for internal business logic and therefore need to be validated separately, none of the users described are allowed to create user grants, at least if they do not own a ZITADEL manager role.
+> Note: Roles are meant for internal business logic and therefore need to be validated separately. None of the users described are allowed to create user grants, at least if they do not own a ZITADEL manager role.
 
-If you made a dashboard where some users are able to create user grants, the Management API to do such operations should be triggered with the personal access token of the users, not with a token of a machine user, to create a meaningful audit log. 
-If you had such a use case, ZITADEL manager roles must be assigned to those users.
+If you made a dashboard where some users can create user grants, trigger the Management API to do operations with the users' personal access token.
+If you have such a use case, assign ZITADEL manager roles to the relevant users.
+To create a meaningful audit log, do not use machine user's token.
 
 ### Noteworthy
 
-Due to the fact that ZITADEL includes unlimited users, projects, and applications and comes with all security features in the FREE tier, ZITADEL can be considered a great alternative to other SaaS IAM systems such as Auth0 or Okta.
-In such a case with this high potential of scalability where user counts can grow explosively, ZITADEL does not become the bottleneck and therefore is the valid choice. You can learn more on ZITADELs benefits and the pricing [here](https://zitadel.ch/pricing).
+Because ZITADEL includes unlimited users, projects, and applications, and because it comes with all security features in the FREE tier, ZITADEL is a great alternative to other SaaS IAM systems such as Auth0 or Okta.
+In cases of high potential scalability, where user counts can grow explosively, ZITADEL does not become the bottleneck.
+[Read more about ZITADELs benefits and pricing](https://zitadel.ch/pricing).
 
 ### Learn more
 

--- a/docs/docs/guides/solution-scenarios/b2b.mdx
+++ b/docs/docs/guides/solution-scenarios/b2b.mdx
@@ -22,7 +22,7 @@ To explain the details and key concepts of a B2B scenario, this topic uses a fic
 
 Octagon tries to solve multiple tasks in the banking field.
 Its portfolio includes several applications for their employees, customers, and partners.
-Some of these applications are web-based, used by only machine users.
+Some of these applications are web-based, other applications are used by machine users only.
 
 When describing multiple-organization scenarios, this topic sometimes also refers to a sub-organization of Octagon, Pentagon.
 
@@ -51,7 +51,7 @@ To define the Portal Application's needs, the application's builders need to con
 
 ### Login
 
-You can decide whether a organization is preselected for the login, or redirected to a login screen.
+You can decide whether an organization is preselected for the login, or redirected to the default login screen.
 
 To set the behavior of the login, go to your projects detail page.
 To send the user to a specific organization, define the organization in a custom scope (primary domain).
@@ -73,8 +73,8 @@ Our sample organization has these users:
 
 - Dimitri: a team leader who is employed by Pentagon, an Octagon department.
   Dimitri uses his Microsoft Account in combination with his one-time password to access the portal.
-  Octagon therefore has set up Microsoft as Identity Provider.
-  Octagon also requires its users to secure their accounts with additional factors.
+  Pentagon therefore has set up Microsoft as Identity Provider.
+  Pentagon also requires its users to secure their accounts with additional factors.
 - Michael: a trainee of Pentagon using the portal only to access his workspace apps.
   Michael uses his Google Account in combination with his laptop's fingerprint.
 - Bill: an employee of Octagon, working as Administrator of the Portal Application.
@@ -104,7 +104,7 @@ Dimitri owns the `writer` role, whereas Michael is only a `reader`.
 
 If you made a dashboard where some users can create user grants, trigger the Management API to do operations with the users' personal access token.
 If you have such a use case, assign ZITADEL manager roles to the relevant users.
-To create a meaningful audit log, do not use machine user's token.
+To create a meaningful audit log, do not use a machine user's token.
 
 ### Noteworthy
 

--- a/docs/docs/guides/solution-scenarios/b2b.mdx
+++ b/docs/docs/guides/solution-scenarios/b2b.mdx
@@ -28,7 +28,7 @@ When describing multiple-organization scenarios, this topic sometimes also refer
 
 ### Portal Application
 
-Octagon has a *Portal application*, where its employees can access their account and list all applications they are allowed to use.
+Octagon has a portal application, where its employees can access their account and list all applications they are allowed to use.
 
 Employees work for a department within Octagon, or for Octagon itself. 
 Some users supervise teams.
@@ -40,7 +40,7 @@ Target groups of the application can be split into:
 
 ### Planning considerations
 
-To define the Portal Application's needs, the application's builders need to consider how the organization is made:
+To define the portal application's needs, the application's builders need to consider how the organization is made:
 
 - Login and Access: Does a user have a preset organization to log in?
   Does the application show the default login page, or does each organization use its own branding?
@@ -56,7 +56,7 @@ You can decide whether an organization is preselected for the login, or redirect
 To set the behavior of the login, go to your projects detail page.
 To send the user to a specific organization, define the organization in a custom scope (primary domain).
 
-To change the branding or the login options of the organization, head to the organization section in [Console](https://console.zitadel.ch/org). 
+To change the branding or the login options of the organization, head to the organization section in the [console](https://console.zitadel.ch/org). 
 You can choose the branding of the selected organization, the user resource owner, or the project's resource owner.
 
 ### Organizations
@@ -69,7 +69,7 @@ If you don't want this feature, create a separate user for each organization.
 To add a user from a different organization to a project's audience, you can add a new user authorization (user grant).
 A user grant combines a user from any organization with a project and 0-N roles.
 
-Our sample organization has these users:
+Our sample organizations have these users:
 
 - Dimitri: a team leader who is employed by Pentagon, an Octagon department.
   Dimitri uses his Microsoft Account in combination with his one-time password to access the portal.
@@ -77,13 +77,18 @@ Our sample organization has these users:
   Pentagon also requires its users to secure their accounts with additional factors.
 - Michael: a trainee of Pentagon using the portal only to access his workspace apps.
   Michael uses his Google Account in combination with his laptop's fingerprint.
-- Bill: an employee of Octagon, working as Administrator of the Portal Application.
+- Bill: an employee of Octagon, working as Administrator of the portal application.
   Bill also uses a Microsoft Account in combination with a Security Key to secure his account.
 
-After you understand the constellation of the organizations and its users, use the
-[Console](https://console.zitadel.ch/org) to set up all the necessary data (Portal project with roles and app, users, login requirements, identity providers, branding).
+After you understand the constellation of the organizations and its users, use the ZITADEL
+[console](https://console.zitadel.ch/org) to set up all the necessary data:
+- portal project with roles and app
+- users
+- login requirements
+- identity providers
+- branding
 
-A sample B2B application for NextJS can be found in our [Example Repo](https://github.com/caos/zitadel-examples).
+A sample B2B application for NextJS can be found in our [example repository](https://github.com/caos/zitadel-examples).
 
 To allow another organization to use a project, create a project grant. Upon creation, you can limit roles for a grant to a subset of the total project roles.
 
@@ -97,7 +102,7 @@ The `admin` role is reserved for the Octagon organization itself.
 
 In this scenario, Dimitri and Michael both belong to the organization Pentagon.
 Bill belongs to Octagon.
-Octagon is owner of the Portal project with its Web App, where Bill is configured as user grant with `admin` role.
+Octagon is owner of the portal project with its Web App, where Bill is configured as user grant with `admin` role.
 Dimitri owns the `writer` role, whereas Michael is only a `reader`.
 
 > Note: Roles are meant for internal business logic and therefore need to be validated separately. None of the users described are allowed to create user grants, at least if they do not own a ZITADEL manager role.
@@ -109,7 +114,7 @@ To create a meaningful audit log, do not use a machine user's token.
 ### Noteworthy
 
 Because ZITADEL includes unlimited users, projects, and applications, and because it comes with all security features in the FREE tier, ZITADEL is a great alternative to other SaaS IAM systems such as Auth0 or Okta.
-In cases of high potential scalability, where user counts can grow explosively, ZITADEL does not become the bottleneck.
+In cases of potentially high scalability demands, where user counts can grow explosively, ZITADEL does not become the bottleneck.
 [Read more about ZITADELs benefits and pricing](https://zitadel.ch/pricing).
 
 ### Learn more

--- a/docs/docs/guides/solution-scenarios/b2c.mdx
+++ b/docs/docs/guides/solution-scenarios/b2c.mdx
@@ -27,7 +27,7 @@ It is the vessel for projects, roles, applications and users.
 You can create an organization from the [ZITADEL console](https://console.zitadel.ch/org/create).
 You can either choose your current account for the organization owner, or create a new one.
 
-Depending on your Software Development Life Cycle (SDLC), you can create multiple organizations or projects, keeping your application environments separated.
+Depending on your *Software Development Life Cycle (SDLC)*, you can create multiple organizations or projects, keeping your application environments separated.
 
 ### Custom domains
 
@@ -57,7 +57,7 @@ Requests to the management API are rate limited. Read our [Rate limit Policy](..
 
 There are multiple ways to perform _User Authentication_.
 The default method in ZITADEL is with a username and password with _Mulitifactor Authentication (MFA)_ enabled.
-To provide good user security, ZITADEL lets you to configure _MFA_ and _Passwordless Authentication_.
+To provide good user security, ZITADEL lets you to configure _MFA_ and passwordless authentication.
 All authentication methods are available from the FREE Tier.
 To set up your organization's login policy, go to your organization's detail in the ZITADEL [console](https://console.zitadel.ch/org).
 
@@ -67,8 +67,8 @@ When planning your application, consider the following questions about User Auth
 - Where will your users enter their credentials?
 - Do you offer password authentication?
 - What do you do to keep user credentials safe?
-- Do you offer Multifactor Authentication?
-- Do you offer Login via an Identity Provider?
+- Do you offer *Multifactor Authentication*?
+- Do you offer Login via an identity provider?
 - Which languages do you have to provide?
 
 Considering these questions, you might admit that building an identity management system is more complex than you initially thought.
@@ -76,7 +76,7 @@ Implementing it yourself might be too much work, especially if you want to focus
 
 ### Federation
 
-ZITADEL supports signup with OIDC Identity providers, as well as JWT Identity Providers.
+ZITADEL supports signup with *OIDC* identity providers, as well as *JWT* identity providers.
 On signup, ZITADEL imports user information to their own profile.
 
 <!---TODO extend this passage---->
@@ -84,7 +84,7 @@ On signup, ZITADEL imports user information to their own profile.
 ### Hosted Login
 
 ZITADEL's approach is _secure by default_.
-It comes with a _Hosted Login_, a fixed endpoint for your users to authenticate.
+It comes with a *Hosted Login*, a fixed endpoint for your users to authenticate.
 It's safe and secure and comes with Multifactor, Federated Login and Passwordless capabilities.
 *OpenID Connect (OIDC)* opens the doors for *Single Sign On (SSO)*.
 Especially if you have more than one application, you may want a central and familiar authentication experience.
@@ -114,26 +114,26 @@ We'd appreciate anyone who contributes to our repo with translations of their la
 
 ### Projects and applications
 
-As our Hosted Login is a separate authentication screen, you have to determine how you direct your users from your applications.
-ZITADEL's Applications live under ZITADEL's Projects.
-You may add multiple applications for your different client-types (Native, Web, User Agent, or API).
-When setting up your applications, consult our [guide about Authentication Flows](../authentication/login-users).
+As our hosted login is a separate authentication screen, you have to determine how you direct your users from your applications.
+ZITADEL's applications live under ZITADEL's projects.
+You may add multiple applications for your different client-types (*Native*, *Web*, *User Agent*, or *API*).
+When setting up your applications, consult our [guide about authentication flows](../authentication/login-users).
 
 ### Access Control
 
 Having authenticated a user, you need to ensure users and services have access to your application and APIs.
-This process is called _Access Control_ and comprises _User Authentication_, Authorization, and Policy Enforcement.
+This process is called access control and comprises user authentication, authorization, and policy enforcement.
 When implementing access control, consider these questions:
 
 - Does your application call your own APIs?
 - Does your application need to call third-party APIs?
-- Do *you* offer an API for third-party applications?
+- Do you offer an API for third-party applications?
 
 The data required to check whether a user has access to a certain API is stored within a user grant.
 This information typically is stored within roles or custom claims.
-You can access it with an `access` or OIDC `id` token.
+You can access it with an `access` or *OIDC* `id` token.
 
-[Read more about Authorization](../authorization/oauth-recommended-flows).
+[Read more about authorization](../authorization/oauth-recommended-flows).
 
 ## Learn more
 

--- a/docs/docs/guides/solution-scenarios/b2c.mdx
+++ b/docs/docs/guides/solution-scenarios/b2c.mdx
@@ -4,31 +4,49 @@ title: B2C
 
 import Column from "../../../src/components/column";
 
+In _Business to Customer (B2C)_ scenarios, your organization works directly with individual users.
+
 ## Business to Consumer
 
-Users in general come with different needs. You may have end users, employees, or even customers from other parties (B2B).
-This groups of users usually don't share the same intentions and use applications differently.
-When planning your applications, investing time in researching your apps architecture is vital for later feature upgrades and enhancements as those changes come in with heftier price points if you have to make bigger changes.
+Generally, users come with different needs.
+You may have end users, employees, or even customers from other parties (B2B).
+These groups of users rarely want to use an app to do the same thing.
+So, they use applications differently.
 
-This guide introduces you to the grouping and structuring of ZITADEL projects which forms the base for all projects. This can be used as a quick start to the [B2B scenario](./b2b), which is merely focused on planning considerations if you are having projects with multiple organizations.
+When planning your applications, be sure to research your app's architecture.
+This is vital for later feature upgrades and enhancements.
+Bigger changes come with heftier price points.
 
-The journey of this guide starts with creating an Organization, the outermost layer of ZITADEL, as it is the vessel for projects, roles, applications and users.
-Creation can be done from [ZITADEL Console](https://console.zitadel.ch/org/create). You can choose your current account for the organization owner or create a new one.
+This topic introduces you to the grouping and structure that forms the basis of all ZITADEL projects.
+The concepts also carry over to B2B scenarios.
+The [B2B scenarios topic](./b2b) focuses on planning considerations when you have projects with multiple organizations.
 
-Depending on your Software Development Life Cycle (SDLC) you can create multiple organizations or projects to keep your applications environments seperated.
+Everything in the following sections assumes you've created an organization.
+An organization is the outermost layer of ZITADEL.
+It is the vessel for projects, roles, applications and users.
+You can create an organization from the [ZITADEL Console](https://console.zitadel.ch/org/create).
+You can choose your current account for the organization owner or create a new one.
 
-### Custom domain
+Depending on your Software Development Life Cycle (SDLC), you can create multiple organizations or projects, keeping your application environments separated.
 
-Right after org creation you'll be greeted with the domain section of your organization. ZITADEL automatically creates a custom domain of the form `[orgname].zitadel.ch`, but you can set your own by saving a verification file on the specified location.  
-We recommend that you create your domains early as they create a sense of confidence and trust for your application and changes later on might create additional migration effort.
-You can read more about how ZITADEL handles usernames [here](../basics/organizations#how-zitadel-handles-usernames).
+### Custom domains
+
+After you create an organization, you'll be greeted with the domain section of your organization.
+ZITADEL automatically creates a custom domain in the form `[orgname].zitadel.ch`, but you can set your own by saving a verification file in the specified location.
+    
+We recommend that you create your domains early.
+This creates a sense of confidence and trust for your application.
+Additionally, changing the domain later might create extra migration effort.
+[Read more about how ZITADEL handles usernames](../basics/organizations#how-zitadel-handles-usernames).
 
 ### Data Provisioning
 
-ZITADEL gives you a basic storage for users and manages phone and email addresses. It also allows you to store your own application data such as preferences or external identifiers to the metadata of a user.
+ZITADEL provides basic storage for users and manages phone and email addresses.
+It also allows you to store your own application data, like preferences or external identifiers, with the user's metadata.
 
-If you are migrating an existing project and you already have an external identity store you can consider bulk importing your user datasets.
-Read our [Management API definitions](../../apis/proto/management#importhumanuser) for more info. If the users email is not verified or no password is set, a initialization mail will be send.
+If you are migrating an existing project and already have an external identity store, consider bulk importing your user datasets.
+Read our [Management API definitions](../../apis/proto/management#importhumanuser) for more info.
+If the user's email is not verified, or if no password is set, a initialization mail will be sent.
 
 :::info
 Requests to the management API are rate limited. Read our [Rate limit Policy](../../legal/rate-limit-policy) for more info.
@@ -36,33 +54,39 @@ Requests to the management API are rate limited. Read our [Rate limit Policy](..
 
 ### User Authentication
 
-User Authentication can be performed in multiple ways. Default method in ZITADEL is username and password with MFA enabled.
-ZITADEL allows you to configure Multifactor- and Passwordless Authentication in order to enhance security for your users. All authentication methods are available from the FREE Tier.
-To setup your organizations login policy, go to your organizations detail in [Console](https://console.zitadel.ch/org).
+There are multiple ways to perform User Authentication.
+The default method in ZITADEL is with a username and password with MFA enabled.
+To enhance user security, ZITADEL lets you to configure Multifactor and Passwordless Authentication.
+All authentication methods are available from the FREE Tier.
+To set up your organization's login policy, go to your organization's detail in [Console](https://console.zitadel.ch/org).
 
-When planning your application consider the following questions about User Authentication:
+When planning your application, consider the following questions about User Authentication:
 
 - What are the methods to authenticate your users?
 - Where will your users enter their credentials?
 - Do you offer password authentication?
-- What do you do to keep your users credentials safe?
+- What do you do to keep user credentials safe?
 - Do you offer Multifactor Authentication?
-- Do you offer Login via Identity Provider?
+- Do you offer Login via an Identity Provider?
 - Which languages do you have to provide?
 
-When looking at this questions, you may have to admit that building an Identity Management System is much more complex and complicated than you thought initially and implementing if yourself may be too much work.
-Particularly because you should focus building your applications.
+Considering these questions, you might admit that building an Identity Management System is much more complex and complicated than you initially thought.
+Implementing it yourself might be too much work, especially if you want to focus on building your applications.
 
 ### Federation
 
-ZITADEL supports signup with OIDC Identity providers as well as JWT Identity Providers. On signup, ZITADEL imports user information to the own profile.
-//TODO extend this passage
+ZITADEL supports signup with OIDC Identity providers, as well as JWT Identity Providers.
+On signup, ZITADEL imports user information to their own profile.
+
+<!---TODO extend this passage---->
 
 ### Hosted Login
 
-ZITADEL offers a "secure by default approach" and comes with a Hosted Login which is a fixed endpoint for your users to authenticate.
+ZITADEL's approach is _secure by default_.
+It comes with a _Hosted Login_, a fixed endpoint for your users to authenticate.
 It's safe and secure and comes with Multifactor, Federated Login and Passwordless capabilities.
-OIDC (OpenID Connect) opens the doors to Single Sign On (SSO). Especially if you have more than one application, you may want a central and familiar authentication experience.
+OIDC (OpenID Connect) opens the doors for Single Sign On (SSO).
+Especially if you have more than one application, you may want a central and familiar authentication experience.
 With SSO, ZITADEL provides a seamless experience across all your apps.
 
 ### Branding
@@ -70,13 +94,18 @@ With SSO, ZITADEL provides a seamless experience across all your apps.
 <Column>
 <div>
 
-Branding and customization is a very important part of your application.
-With ZITADEL you can modify colors, logos, icons as well as configure your typography styles, such that you can provide a consistent design throughout your applications.
-In addition to visual modifications, you can edit notification texts for your users.
-ZITADEL gives you handlebar similar templating for variables. Of course you can define texts for any language.
-We'd appreciate if you could contribute to our repo with translations of your language. Read on how to contribute [here](../../guides/customization/texts).
+Branding and customization is an important part of your application.
+With ZITADEL, you can modify colors, logos, and icons.
+You can also configure your typography styles.
+These branding customizations let you provide a consistent design throughout your applications.
 
-> Note that your console design changes to your design too
+In addition to visual modifications, you can edit notification texts for your users.
+ZITADEL gives you handlebar-like templating for variables.
+Of course you can define texts for any language.
+We'd appreciate if you could contribute to our repo with translations of your language. 
+[Read about how to contribute](../../guides/customization/texts).
+
+> Note that your console design will also change for your branding.
 
 </div>
 <img src="/img/guides/branding.jpeg" alt="branding in console"/>
@@ -84,21 +113,26 @@ We'd appreciate if you could contribute to our repo with translations of your la
 
 ### Projects and applications
 
-As our Hosted Login is a separate authentication screen, you have to determine how you are directing your users from your applications.
-ZITADEL's Applications live under ZITADEL's Projects. You may add multiple applications for your different client-types (Native, Web, User Agent, or API). When setting up your applications consider reading our guide about [Authentication Flows](../authentication/login-users).
+As our Hosted Login is a separate authentication screen, you have to determine how you direct your users from your applications.
+ZITADEL's Applications live under ZITADEL's Projects.
+You may add multiple applications for your different client-types (Native, Web, User Agent, or API).
+When setting up your applications, consult our [guide about Authentication Flows](../authentication/login-users).
 
 ### Access Control
 
-By having authenticated a user you need to ensure users and services have access to your application and APIs. This process is called Access Control and comprises User Authentication, Authorization and Policy Enforcement.
-Take the following considerations:
+Having authenticated a user, you need to ensure users and services have access to your application and APIs.
+This process is called _Access Control_ and comprises User Authentication, Authorization, and Policy Enforcement.
+When implementing access control, consider these questions:
 
 - Does your application call your own APIs?
 - Does your application need to call third-party APIs?
-- Do **you** offer an API for third-party applications?
+- Do *you* offer an API for third-party applications?
 
-The data required to check if a user has access to a certain API is stored within a user grant. This information typically is stored within roles or custom claims and can be accessed with an `access` or OIDC `id` token.
+The data required to check whether a user has access to a certain API is stored within a user grant.
+This information typically is stored within roles or custom claims.
+You can access it with an `access` or OIDC `id` token.
 
-Read more about Authorization in our [Guide](../authorization/oauth-recommended-flows).
+[Read more about Authorization](../authorization/oauth-recommended-flows).
 
 ## Learn more
 

--- a/docs/docs/guides/solution-scenarios/b2c.mdx
+++ b/docs/docs/guides/solution-scenarios/b2c.mdx
@@ -8,12 +8,11 @@ In _Business to Customer (B2C)_ scenarios, your organization works directly with
 
 ## Business to Consumer
 
-Generally, users come with different needs.
+Users come with different needs.
 You may have end users, employees, or even customers from other parties (B2B).
-These groups of users rarely want to use an app to do the same thing.
-So, they use applications differently.
+These groups of users rarely want to use an app to do the exactly same thing.
 
-When planning your applications, be sure to research your app's architecture.
+When planning your applications, be sure to research your user use cases and your app's architecture.
 This is vital for later feature upgrades and enhancements.
 Bigger changes come with heftier price points.
 
@@ -25,7 +24,7 @@ Everything in the following sections assumes you've created an organization.
 An organization is the outermost layer of ZITADEL.
 It is the vessel for projects, roles, applications and users.
 You can create an organization from the [ZITADEL Console](https://console.zitadel.ch/org/create).
-You can choose your current account for the organization owner or create a new one.
+You can either choose your current account for the organization owner, or create a new one.
 
 Depending on your Software Development Life Cycle (SDLC), you can create multiple organizations or projects, keeping your application environments separated.
 
@@ -41,12 +40,13 @@ Additionally, changing the domain later might create extra migration effort.
 
 ### Data Provisioning
 
-ZITADEL provides basic storage for users and manages phone and email addresses.
-It also allows you to store your own application data, like preferences or external identifiers, with the user's metadata.
+ZITADEL provides basic storage for users.
+It manages phone and email addresses,
+and also allows you to store your own application data, like preferences or external identifiers, with the user's metadata.
 
 If you are migrating an existing project and already have an external identity store, consider bulk importing your user datasets.
 Read our [Management API definitions](../../apis/proto/management#importhumanuser) for more info.
-If the user's email is not verified, or if no password is set, a initialization mail will be sent.
+If the user's email is not verified, or if no password is set, ZITADEL sends an initialization email.
 
 :::info
 Requests to the management API are rate limited. Read our [Rate limit Policy](../../legal/rate-limit-policy) for more info.
@@ -70,7 +70,7 @@ When planning your application, consider the following questions about User Auth
 - Do you offer Login via an Identity Provider?
 - Which languages do you have to provide?
 
-Considering these questions, you might admit that building an Identity Management System is much more complex and complicated than you initially thought.
+Considering these questions, you might admit that building an Identity Management System is more complex than you initially thought.
 Implementing it yourself might be too much work, especially if you want to focus on building your applications.
 
 ### Federation
@@ -102,7 +102,7 @@ These branding customizations let you provide a consistent design throughout you
 In addition to visual modifications, you can edit notification texts for your users.
 ZITADEL gives you handlebar-like templating for variables.
 Of course you can define texts for any language.
-We'd appreciate if you could contribute to our repo with translations of your language. 
+We'd appreciate anyone who contributes to our repo with translations of their language.
 [Read about how to contribute](../../guides/customization/texts).
 
 > Note that your console design will also change for your branding.

--- a/docs/docs/guides/solution-scenarios/b2c.mdx
+++ b/docs/docs/guides/solution-scenarios/b2c.mdx
@@ -5,14 +5,15 @@ title: B2C
 import Column from "../../../src/components/column";
 
 In _Business to Customer (B2C)_ scenarios, your organization works directly with individual users.
+This is different from typical [B2B](./b2b) cases, where the organization often interacts with other organizations.
 
 ## Business to Consumer
 
 Users come with different needs.
 You may have end users, employees, or even customers from other parties (B2B).
-These groups of users rarely want to use an app to do the exactly same thing.
+These groups of users rarely want to use an app to do the exact same thing.
 
-When planning your applications, be sure to research your user use cases and your app's architecture.
+When planning your applications, be sure to research your users' use cases and your app's architecture.
 This is vital for later feature upgrades and enhancements.
 Bigger changes come with heftier price points.
 
@@ -85,7 +86,7 @@ On signup, ZITADEL imports user information to their own profile.
 ZITADEL's approach is _secure by default_.
 It comes with a _Hosted Login_, a fixed endpoint for your users to authenticate.
 It's safe and secure and comes with Multifactor, Federated Login and Passwordless capabilities.
-OIDC (OpenID Connect) opens the doors for Single Sign On (SSO).
+*OpenID Connect (OIDC)* opens the doors for *Single Sign On (SSO)*.
 Especially if you have more than one application, you may want a central and familiar authentication experience.
 With SSO, ZITADEL provides a seamless experience across all your apps.
 
@@ -100,7 +101,7 @@ You can also configure your typography styles.
 These branding customizations let you provide a consistent design throughout your applications.
 
 In addition to visual modifications, you can edit notification texts for your users.
-ZITADEL gives you handlebar-like templating for variables.
+ZITADEL gives you [Handlebars-like templating](https://handlebarsjs.com/) for variables.
 Of course you can define texts for any language.
 We'd appreciate anyone who contributes to our repo with translations of their language.
 [Read about how to contribute](../../guides/customization/texts).

--- a/docs/docs/guides/solution-scenarios/b2c.mdx
+++ b/docs/docs/guides/solution-scenarios/b2c.mdx
@@ -24,7 +24,7 @@ The [B2B scenarios topic](./b2b) focuses on planning considerations when you hav
 Everything in the following sections assumes you've created an organization.
 An organization is the outermost layer of ZITADEL.
 It is the vessel for projects, roles, applications and users.
-You can create an organization from the [ZITADEL Console](https://console.zitadel.ch/org/create).
+You can create an organization from the [ZITADEL console](https://console.zitadel.ch/org/create).
 You can either choose your current account for the organization owner, or create a new one.
 
 Depending on your Software Development Life Cycle (SDLC), you can create multiple organizations or projects, keeping your application environments separated.
@@ -55,11 +55,11 @@ Requests to the management API are rate limited. Read our [Rate limit Policy](..
 
 ### User Authentication
 
-There are multiple ways to perform User Authentication.
-The default method in ZITADEL is with a username and password with MFA enabled.
-To enhance user security, ZITADEL lets you to configure Multifactor and Passwordless Authentication.
+There are multiple ways to perform _User Authentication_.
+The default method in ZITADEL is with a username and password with _Mulitifactor Authentication (MFA)_ enabled.
+To provide good user security, ZITADEL lets you to configure _MFA_ and _Passwordless Authentication_.
 All authentication methods are available from the FREE Tier.
-To set up your organization's login policy, go to your organization's detail in [Console](https://console.zitadel.ch/org).
+To set up your organization's login policy, go to your organization's detail in the ZITADEL [console](https://console.zitadel.ch/org).
 
 When planning your application, consider the following questions about User Authentication:
 
@@ -71,7 +71,7 @@ When planning your application, consider the following questions about User Auth
 - Do you offer Login via an Identity Provider?
 - Which languages do you have to provide?
 
-Considering these questions, you might admit that building an Identity Management System is more complex than you initially thought.
+Considering these questions, you might admit that building an identity management system is more complex than you initially thought.
 Implementing it yourself might be too much work, especially if you want to focus on building your applications.
 
 ### Federation
@@ -122,7 +122,7 @@ When setting up your applications, consult our [guide about Authentication Flows
 ### Access Control
 
 Having authenticated a user, you need to ensure users and services have access to your application and APIs.
-This process is called _Access Control_ and comprises User Authentication, Authorization, and Policy Enforcement.
+This process is called _Access Control_ and comprises _User Authentication_, Authorization, and Policy Enforcement.
 When implementing access control, consider these questions:
 
 - Does your application call your own APIs?

--- a/docs/docs/guides/solution-scenarios/introduction.mdx
+++ b/docs/docs/guides/solution-scenarios/introduction.mdx
@@ -11,10 +11,10 @@ import Column from "../../../src/components/column";
 
 ## Solution Scenarios
 
-Customers all have different use cases for their SaaS Identity and Access Management Systems.
+Customers all have different use cases for their SaaS identity and access management systems.
 
-This guide outlines the real-world concepts you need to think about when integrating an Access Management System.
-It breaks these concepts down into different use cases, called _Solution Scenarios_.
+This guide outlines the real-world concepts you need to think about when integrating an access management system.
+It breaks these concepts down into different solution scenarios.
 You can use these scenarios as models to help you get started with ZITADEL.
 
 <ListWrapper title="Solution Scenarios">

--- a/docs/docs/guides/solution-scenarios/introduction.mdx
+++ b/docs/docs/guides/solution-scenarios/introduction.mdx
@@ -14,7 +14,7 @@ import Column from "../../../src/components/column";
 Customers all have different use cases for their SaaS Identity and Access Management Systems.
 
 This guide outlines the real-world concepts you need to think about when implementing an Access Management System.
-It breaks these concepts into different use cases, called _Solution Scenarios_.
+It breaks these concepts down into different use cases, called _Solution Scenarios_.
 You can use these scenarios as models to help you get started with ZITADEL.
 
 <ListWrapper title="Solution Scenarios">

--- a/docs/docs/guides/solution-scenarios/introduction.mdx
+++ b/docs/docs/guides/solution-scenarios/introduction.mdx
@@ -13,7 +13,7 @@ import Column from "../../../src/components/column";
 
 Customers all have different use cases for their SaaS Identity and Access Management Systems.
 
-This guide outlines the real-world concepts you need to think about when implementing an Access Management System.
+This guide outlines the real-world concepts you need to think about when integrating an Access Management System.
 It breaks these concepts down into different use cases, called _Solution Scenarios_.
 You can use these scenarios as models to help you get started with ZITADEL.
 

--- a/docs/docs/guides/solution-scenarios/introduction.mdx
+++ b/docs/docs/guides/solution-scenarios/introduction.mdx
@@ -11,8 +11,11 @@ import Column from "../../../src/components/column";
 
 ## Solution Scenarios
 
-Customers of an SaaS Identity and Access Management System usually have all distinct use cases and requirements.
-This guide attempts to explain real-world implementations and break them down into **Solution Scenarios** which aim to help you getting started with ZITADEL.
+Customers all have different use cases for their SaaS Identity and Access Management Systems.
+
+This guide outlines the real-world concepts you need to think about when implementing an Access Management System.
+It breaks these concepts into different use cases, called _Solution Scenarios_.
+You can use these scenarios as models to help you get started with ZITADEL.
 
 <ListWrapper title="Solution Scenarios">
   <ListElement

--- a/docs/docs/guides/trainings/introduction.md
+++ b/docs/docs/guides/trainings/introduction.md
@@ -8,13 +8,14 @@ The following pages describe the recommended training sessions for managing and 
 
 ![Support Services Training](/img/training_support_services.png)
 
-When entering into a support services agreement with us, we recommend the following trainings:
+When entering a support services agreement with us, we recommend the following training sessions.
 
 * [Operations training](supportservice/operations)
 * [Application Support training](supportservice/application)
 * [Recurring training](supportservice/recurring)
 
-Additionally, you will benefit from sufficient time with a technical account manager in your support plan to clarify questions and get expert advice beyond solving support issues.
+You will also benefit from spending time with a technical account manager in your support plan.
+In this time, you can clarify questions you had and get expert advice beyond solving support issues.
 
 Training should be held as block-sessions with the relevant staff from your organization. 
 

--- a/docs/docs/guides/trainings/supportservice/application.md
+++ b/docs/docs/guides/trainings/supportservice/application.md
@@ -4,7 +4,7 @@ title: Application Support Trainings
 
 ## ZITADEL Support
 
-In this session your second level support will gain an understanding on how to extract relevant information for technical support questions and root cause analysis.
+In this session your second-level support will gain an understanding of how to extract relevant information for technical support questions and root cause analysis.
 
 **Audience**: 2nd Level Support Staff  
 **Duration**: 0.5 day
@@ -23,7 +23,8 @@ In this session your second level support will gain an understanding on how to e
 
 ## ZITADEL Administrator
 
-In this hands-on training your employees will get a complete overview of the system and learn how to configure and use ZITADEL. Your support staff will gain the required knowledge to provide user-support, while your solution owners gain an understanding about integration of clients.
+In this hands-on training, your employees will get a complete overview of the system and learn how to configure and use ZITADEL.
+Your support staff will gain the required knowledge to provide user-support, while your solution owners gain an understanding about integration of clients.
 
 **Audience**: 1st / 2nd Level Support Staff, Solution Owner, QA Manager (optional)  
 **Duration**: 1.5 days

--- a/docs/docs/guides/trainings/supportservice/operations.md
+++ b/docs/docs/guides/trainings/supportservice/operations.md
@@ -4,7 +4,9 @@ title: Operations Trainings
 
 ## ORBOS Basics
 
-In this hands-on training you will gain an understanding about GitOps and ORBOS and learn how to install and manage ORBOS. We will share best practices around installation, management and configuration.
+In this hands-on training, you will gain an understanding about GitOps and ORBOS.
+You'll also learn how to install and manage ORBOS.
+We share best practices around installation, management and configuration.
 
 **Audience**: DevOps Engineer  
 **Duration**: 1.5 days
@@ -26,7 +28,7 @@ In this hands-on training you will gain an understanding about GitOps and ORBOS 
 
 ## ZITADEL and DB Operator 
 
-In this hands-on training you will gain an in-depth understanding of the ZITADEL and DB Operators with our standard toolset.
+In this hands-on training, you will gain an in-depth understanding of the ZITADEL and DB Operators with our standard toolset.
 
 **Audience**: DevOps Engineer  
 **Duration**: 1.5 days
@@ -47,7 +49,8 @@ In this hands-on training you will gain an in-depth understanding of the ZITADEL
 
 ## ORBOS Tooling
 
-In this training you will learn how to customize tooling or more detailed aspects of the product. This is optional when using our recommended tooling and configuration to operate ZITADEL in standard scenarios.
+In this training you will learn how to customize tooling or more detailed aspects of the product.
+This is optional when using our recommended tooling and configuration to operate ZITADEL in standard scenarios.
 
 **Audience**: DevOps Engineer  
 **Duration**: 1.5 days

--- a/docs/docs/guides/trainings/supportservice/recurring.md
+++ b/docs/docs/guides/trainings/supportservice/recurring.md
@@ -6,7 +6,7 @@ title: Recurring Trainings
 
 In this session you can refresh your knowledge about existing concepts, and gain experience with new features of ZITADEL.
 This keeps the quality of your support high.
-We recommend an one day of training per support staff.
+We recommend one day of training per support staff.
 
 **Audience**: 1st / 2nd Level Support Staff, Solution Owner, QA Manager (optional)  
 **Duration**: 1 day / support staff

--- a/docs/docs/guides/trainings/supportservice/recurring.md
+++ b/docs/docs/guides/trainings/supportservice/recurring.md
@@ -4,14 +4,16 @@ title: Recurring Trainings
 
 ## ZITADEL Support Refresher
 
-In this session you can refresh knowledge about existing and gain experience with new features of ZITADEL to keep the quality of your support high. We recommend an one day training per support staff.
+In this session you can refresh your knowledge about existing concepts, and gain experience with new features of ZITADEL.
+This keeps the quality of your support high.
+We recommend an one day of training per support staff.
 
 **Audience**: 1st / 2nd Level Support Staff, Solution Owner, QA Manager (optional)  
 **Duration**: 1 day / support staff
 
 **Topics covered**:
 
-* Walk-through new features
+* Walk-through of new features
 * Review of difficult support issues
 * Review of customer feedback
 * Q&A
@@ -20,7 +22,7 @@ In this session you can refresh knowledge about existing and gain experience wit
 
 ## ZITADEL Support Onboarding
 
-In this hands-on training new support staff will get an overview of the system and learn how to configure and use ZITADEL to provide support for users.
+In this hands-on training, new support staff get an overview of the system and learn how to configure and use ZITADEL to provide support for users.
 
 **Audience**: 1st / 2nd Level Support Staff, Solution Owner, QA Manager (optional)  
 **Duration**: 0.5 days / support staff

--- a/docs/docs/manuals/introduction.mdx
+++ b/docs/docs/manuals/introduction.mdx
@@ -19,7 +19,7 @@ In this section we provide manuals for different user profiles.
       <ListElement link="/docs/manuals/user-factors" type={ICONTYPE.HELP_FACTORS} title="Factors" description="Enable multifactor authentication for more security" />
       <ListElement link="/docs/manuals/user-email" type={ICONTYPE.HELP_EMAIL} title="Email" description="How to change your email" />
       <ListElement link="/docs/manuals/user-phone" type={ICONTYPE.HELP_PHONE} title="Phone" description="How to change your phonenumber" />
-      <ListElement link="/docs/manuals/user-social-login" type={ICONTYPE.HELP_SOCIAL} title="Social Login" description="Link an external Identity Provider with your account" />   
+      <ListElement link="/docs/manuals/user-social-login" type={ICONTYPE.HELP_SOCIAL} title="Social Login" description="Link an external identity provider with your account" />   
     </div>
   </Column> 
 </ListWrapper>

--- a/docs/docs/manuals/user-factors.md
+++ b/docs/docs/manuals/user-factors.md
@@ -33,7 +33,7 @@ In general there might be the following possibilities:
 - FaceRecognition (e.g. FaceID)
 - Hardware Tokens (e.g. YubiKey, Solokeys)
 
-Hardware Tokens are basically a piece of hardware such as a USB key that gets linked to your Identity and authorizes as second factor when a button on the device is pressed.
+Hardware Tokens are basically a piece of hardware such as a USB key that gets linked to your identity and authorizes as second factor when a button on the device is pressed.
 
 :::info
 Some example Keys are [Solokeys](https://solokeys.com) or [Yubikey](https://www.yubico.com/) You can choose the one you like the most.

--- a/docs/docs/manuals/user-passwordless.md
+++ b/docs/docs/manuals/user-passwordless.md
@@ -24,5 +24,5 @@ This doesn't count for hardware tokens, as these are device independent.
 :::
 
 
-![Add Passwordless](/img/manuals/console_add_passwordless_direct.gif)
+![Add passwordless](/img/manuals/console_add_passwordless_direct.gif)
 

--- a/docs/docs/manuals/user-register.md
+++ b/docs/docs/manuals/user-register.md
@@ -4,13 +4,13 @@ title: User Register
 
 ## Organization and user registration
 
-Zitadel allows users to register a organization and/or user with just a few steps.
+ZITADEL allows users to register a organization and/or user with just a few steps.
 
 A. Register an organization
 
  1. Create an organization
  2. Verify your email
- 3. Login to Zitadel and manage the organization
+ 3. Login to ZITADEL and manage the organization
 
 B. Create User
  1. An administrator can create and manage users within console.

--- a/docs/docs/manuals/user-social-login.md
+++ b/docs/docs/manuals/user-social-login.md
@@ -4,14 +4,14 @@ title: Social Login
 
 ## Identity Linking
 
-To link an external Identity Provider with a Zitadel Account you have to:
+To link an external identity provider with a ZITADEL account you have to:
 
 1. choose your IDP
 2. Login to your IDP
 
 you can then either
 
-1. link the Identity to an existing ZITADEL useraccount
+1. link the identity to an existing ZITADEL useraccount
 2. auto register a new ZITADEL useraccount
 
 

--- a/docs/docs/quickstarts/identity-proxy/oauth2-proxy.md
+++ b/docs/docs/quickstarts/identity-proxy/oauth2-proxy.md
@@ -4,7 +4,7 @@ title: OAuth 2.0 Proxy
 
 [OAuth2-proxy](https://github.com/oauth2-proxy/oauth2-proxy) is a project which allows services to delegate the authentication flow to a IDP, for example **ZITADEL**
 
-## Configure Zitadel
+## Configure ZITADEL
 
 ### Setup Application and get Keys
 

--- a/docs/docs/quickstarts/login/nextjs.md
+++ b/docs/docs/quickstarts/login/nextjs.md
@@ -2,7 +2,7 @@
 title: Next.js
 ---
 
-This is our Zitadel [Next.js](https://nextjs.org/) template. It shows how to authenticate as a user and retrieve user information from the OIDC endpoint.
+This is our ZITADEL [Next.js](https://nextjs.org/) template. It shows how to authenticate as a user and retrieve user information from the OIDC endpoint.
 
 > The template code is part of our zitadel-example repo. Take a look [here](https://github.com/caos/zitadel-examples/tree/main/nextjs).
 


### PR DESCRIPTION
This PR makes some major line edits to the "guides" section of the docs. In a few cases, I've added intros, or rewritten them to create a better flow between paragraphs and pages.

Some common edits are:
* Using bold for UI elements, italics for special terms, and monospace for variables and code
* rewriting passive tense into active tense
* breaking paragraphs up into distinct ideas, and using lists for instructions (following guidelines here: https://docs.microsoft.com/en-us/style-guide/scannable-content/)