### PR TITLE
fix: correct login names on auth and notification users

### DIFF
--- a/internal/eventstore/handler/handler_projection.go
+++ b/internal/eventstore/handler/handler_projection.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/caos/logging"
+
 	"github.com/caos/zitadel/internal/eventstore"
 )
 

--- a/internal/notification/repository/eventsourcing/handler/notify_user.go
+++ b/internal/notification/repository/eventsourcing/handler/notify_user.go
@@ -3,13 +3,13 @@ package handler
 import (
 	"context"
 
+	"github.com/caos/logging"
+
 	caos_errs "github.com/caos/zitadel/internal/errors"
-	"github.com/caos/zitadel/internal/eventstore/v1"
+	v1 "github.com/caos/zitadel/internal/eventstore/v1"
 	es_sdk "github.com/caos/zitadel/internal/eventstore/v1/sdk"
 	org_view "github.com/caos/zitadel/internal/org/repository/view"
 	query2 "github.com/caos/zitadel/internal/query"
-
-	"github.com/caos/logging"
 
 	es_models "github.com/caos/zitadel/internal/eventstore/v1/models"
 	"github.com/caos/zitadel/internal/eventstore/v1/query"
@@ -166,23 +166,16 @@ func (u *NotifyUser) ProcessOrg(event *es_models.Event) (err error) {
 }
 
 func (u *NotifyUser) fillLoginNamesOnOrgUsers(event *es_models.Event) error {
-	org, err := u.getOrgByID(context.Background(), event.ResourceOwner)
+	userLoginMustBeDomain, _, domains, err := u.loginNameInformation(context.Background(), event.ResourceOwner)
 	if err != nil {
 		return err
-	}
-	policy := new(query2.OrgIAMPolicy)
-	if policy == nil {
-		policy, err = u.getDefaultOrgIAMPolicy(context.Background())
-		if err != nil {
-			return err
-		}
 	}
 	users, err := u.view.NotifyUsersByOrgID(event.AggregateID)
 	if err != nil {
 		return err
 	}
 	for _, user := range users {
-		user.SetLoginNames(policy, org.Domains)
+		user.SetLoginNames(userLoginMustBeDomain, domains)
 		err := u.view.PutNotifyUser(user, event)
 		if err != nil {
 			return err
@@ -192,16 +185,11 @@ func (u *NotifyUser) fillLoginNamesOnOrgUsers(event *es_models.Event) error {
 }
 
 func (u *NotifyUser) fillPreferredLoginNamesOnOrgUsers(event *es_models.Event) error {
-	org, err := u.getOrgByID(context.Background(), event.ResourceOwner)
+	userLoginMustBeDomain, primaryDomain, _, err := u.loginNameInformation(context.Background(), event.ResourceOwner)
 	if err != nil {
 		return err
 	}
-
-	policy, err := u.getDefaultOrgIAMPolicy(context.Background())
-	if err != nil {
-		return err
-	}
-	if !policy.UserLoginMustBeDomain {
+	if !userLoginMustBeDomain {
 		return nil
 	}
 	users, err := u.view.NotifyUsersByOrgID(event.AggregateID)
@@ -209,7 +197,7 @@ func (u *NotifyUser) fillPreferredLoginNamesOnOrgUsers(event *es_models.Event) e
 		return err
 	}
 	for _, user := range users {
-		user.PreferredLoginName = user.GenerateLoginName(org.GetPrimaryDomain().Domain, policy.UserLoginMustBeDomain)
+		user.PreferredLoginName = user.GenerateLoginName(primaryDomain, userLoginMustBeDomain)
 		err := u.view.PutNotifyUser(user, event)
 		if err != nil {
 			return err
@@ -219,17 +207,12 @@ func (u *NotifyUser) fillPreferredLoginNamesOnOrgUsers(event *es_models.Event) e
 }
 
 func (u *NotifyUser) fillLoginNames(user *view_model.NotifyUser) (err error) {
-	org, err := u.getOrgByID(context.Background(), user.ResourceOwner)
+	userLoginMustBeDomain, primaryDomain, domains, err := u.loginNameInformation(context.Background(), user.ResourceOwner)
 	if err != nil {
 		return err
 	}
-
-	policy, err := u.getDefaultOrgIAMPolicy(context.Background())
-	if err != nil {
-		return err
-	}
-	user.SetLoginNames(policy, org.Domains)
-	user.PreferredLoginName = user.GenerateLoginName(org.GetPrimaryDomain().Domain, policy.UserLoginMustBeDomain)
+	user.SetLoginNames(userLoginMustBeDomain, domains)
+	user.PreferredLoginName = user.GenerateLoginName(primaryDomain, userLoginMustBeDomain)
 	return nil
 }
 
@@ -264,6 +247,17 @@ func (u *NotifyUser) getOrgByID(ctx context.Context, orgID string) (*org_model.O
 	return org_es_model.OrgToModel(esOrg), nil
 }
 
-func (u *NotifyUser) getDefaultOrgIAMPolicy(ctx context.Context) (*query2.OrgIAMPolicy, error) {
-	return u.queries.DefaultOrgIAMPolicy(ctx)
+func (u *NotifyUser) loginNameInformation(ctx context.Context, orgID string) (userLoginMustBeDomain bool, primaryDomain string, domains []*org_model.OrgDomain, err error) {
+	org, err := u.getOrgByID(ctx, orgID)
+	if err != nil {
+		return false, "", nil, err
+	}
+	if org.OrgIamPolicy == nil {
+		policy, err := u.queries.DefaultOrgIAMPolicy(ctx)
+		if err != nil {
+			return false, "", nil, err
+		}
+		userLoginMustBeDomain = policy.UserLoginMustBeDomain
+	}
+	return userLoginMustBeDomain, org.GetPrimaryDomain().Domain, org.Domains, nil
 }

--- a/internal/user/repository/view/model/notify_user.go
+++ b/internal/user/repository/view/model/notify_user.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/caos/zitadel/internal/query"
-
 	"github.com/caos/logging"
 	"github.com/lib/pq"
 
@@ -99,14 +97,14 @@ func (u *NotifyUser) GenerateLoginName(domain string, appendDomain bool) string 
 	return u.UserName + "@" + domain
 }
 
-func (u *NotifyUser) SetLoginNames(policy *query.OrgIAMPolicy, domains []*org_model.OrgDomain) {
+func (u *NotifyUser) SetLoginNames(userLoginMustBeDomain bool, domains []*org_model.OrgDomain) {
 	loginNames := make([]string, 0)
 	for _, d := range domains {
 		if d.Verified {
 			loginNames = append(loginNames, u.GenerateLoginName(d.Domain, true))
 		}
 	}
-	if !policy.UserLoginMustBeDomain {
+	if !userLoginMustBeDomain {
 		loginNames = append(loginNames, u.UserName)
 	}
 	u.LoginNames = loginNames

--- a/internal/user/repository/view/model/user.go
+++ b/internal/user/repository/view/model/user.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/caos/logging"
-	"github.com/caos/zitadel/internal/query"
 	"github.com/lib/pq"
 
 	req_model "github.com/caos/zitadel/internal/auth_request/model"
@@ -227,14 +226,14 @@ func (u *UserView) GenerateLoginName(domain string, appendDomain bool) string {
 	return u.UserName + "@" + domain
 }
 
-func (u *UserView) SetLoginNames(policy *query.OrgIAMPolicy, domains []*org_model.OrgDomain) {
+func (u *UserView) SetLoginNames(userLoginMustBeDomain bool, domains []*org_model.OrgDomain) {
 	loginNames := make([]string, 0)
 	for _, d := range domains {
 		if d.Verified {
 			loginNames = append(loginNames, u.GenerateLoginName(d.Domain, true))
 		}
 	}
-	if !policy.UserLoginMustBeDomain {
+	if !userLoginMustBeDomain {
 		loginNames = append(loginNames, u.UserName)
 	}
 	u.LoginNames = loginNames

--- a/migrations/cockroach/V1.112__login_names.sql
+++ b/migrations/cockroach/V1.112__login_names.sql
@@ -1,0 +1,30 @@
+WITH doa AS (
+    SELECT l1.user_id, array_agg(l1.login_name)::STRING as login_names, l2.login_name as preferred_login_name
+    FROM zitadel.projections.login_names l1
+    JOIN (SELECT user_id, login_name FROM zitadel.projections.login_names WHERE is_primary) l2
+        ON l1.user_id = l2.user_id
+    WHERE l1.user_id in (
+        SELECT id FROM notification.notify_users u
+           LEFT JOIN zitadel.projections.login_names n
+                ON n.user_id = u.id
+        WHERE u.preferred_login_name <> n.login_name AND n.is_primary
+    )
+    GROUP BY l1.user_id, l2.login_name
+)
+UPDATE notification.notify_users SET preferred_login_name = doa.preferred_login_name, login_names = doa.login_names FROM doa WHERE doa.user_id = notification.notify_users.id;
+
+WITH doa AS (
+    SELECT l1.user_id, array_agg(l1.login_name) as login_names, l2.login_name as preferred_login_name
+    FROM zitadel.projections.login_names l1
+    JOIN (SELECT user_id, login_name FROM zitadel.projections.login_names WHERE is_primary) l2
+      ON l1.user_id = l2.user_id
+    WHERE l1.user_id in (
+        SELECT id FROM auth.users u
+            LEFT JOIN zitadel.projections.login_names n
+                ON n.user_id = u.id
+        WHERE u.preferred_login_name <> n.login_name AND n.is_primary
+    )
+    GROUP BY l1.user_id, l2.login_name
+)
+UPDATE auth.users SET preferred_login_name = doa.preferred_login_name, login_names = doa.login_names FROM doa WHERE doa.user_id = auth.users.id;
+

--- a/migrations/cockroach/V1.112__login_names.sql
+++ b/migrations/cockroach/V1.112__login_names.sql
@@ -3,12 +3,6 @@ WITH doa AS (
     FROM zitadel.projections.login_names l1
     JOIN (SELECT user_id, login_name FROM zitadel.projections.login_names WHERE is_primary) l2
         ON l1.user_id = l2.user_id
-    WHERE l1.user_id in (
-        SELECT id FROM notification.notify_users u
-           LEFT JOIN zitadel.projections.login_names n
-                ON n.user_id = u.id
-        WHERE u.preferred_login_name <> n.login_name AND n.is_primary
-    )
     GROUP BY l1.user_id, l2.login_name
 )
 UPDATE notification.notify_users SET preferred_login_name = doa.preferred_login_name, login_names = doa.login_names FROM doa WHERE doa.user_id = notification.notify_users.id;
@@ -18,13 +12,6 @@ WITH doa AS (
     FROM zitadel.projections.login_names l1
     JOIN (SELECT user_id, login_name FROM zitadel.projections.login_names WHERE is_primary) l2
       ON l1.user_id = l2.user_id
-    WHERE l1.user_id in (
-        SELECT id FROM auth.users u
-            LEFT JOIN zitadel.projections.login_names n
-                ON n.user_id = u.id
-        WHERE u.preferred_login_name <> n.login_name AND n.is_primary
-    )
     GROUP BY l1.user_id, l2.login_name
 )
 UPDATE auth.users SET preferred_login_name = doa.preferred_login_name, login_names = doa.login_names FROM doa WHERE doa.user_id = auth.users.id;
-


### PR DESCRIPTION
Some login names and preferred login names were incorrectly built in views required during login. They had an additional login names entry with missing domain suffix from org, which then was also set as their preferred login name.
The new projection tables are correct and are used for looking up the user when trying to reset the password for example. therefor the users could not be found due to the different data.
This also fixes a similar issue in the notifications table where the almost exactly same problem exists.